### PR TITLE
Support for ver 1 track files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The version number of the file is stored as WORD at 0x0008.
 - Track/Route files of the old Nokia SportsTracker (ver1):     10000 <= version < 20000.
 - Track log files of Symbian SportsTracker (ver2):             20000 <= version.
 
-The script was tested for the old and the new NST versions of 9991-9998, 10102 and 20001-20002.
+The track reading script was tested for the old and the new NST versions of 9991-9998, 10102 and 20001-20002.
+The route reading one was tested for version of 11400.
 
  The file formats of symbian are completely different from those of Android and iOS.
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This code works also for track/route files created by **the old Nokia Sports Tra
 version released from [Sports Tracking Technologies Ltd](http://www.sports-tracker.com/).  For details, please see the codes.  (1-byte instead 
 of 2-byte long header, start address of trackpoint is different, etc.)
 
-The version number of the app used to create the file is stored as WORD at 0x0008.
-- Track log files of the old Nokia SportsTracker:          version < 10000.
-- Route files of the old Nokia SportsTracker:     10000 <= version < 20000.
-- Track log files of Symbian SportsTracker:       20000 <= version.
+The version number of the file is stored as WORD at 0x0008.
+- Track log files of the old Nokia SportsTracker (ver0):                version < 10000.
+- Track/Route files of the old Nokia SportsTracker (ver1):     10000 <= version < 20000.
+- Track log files of Symbian SportsTracker (ver2):             20000 <= version.
 
-The script was tested for the old and the new NST versions of 9991-9998 and 20001-20002, respectively.
+The script was tested for the old and the new NST versions of 9991-9998, 10102 and 20001-20002.
 
  The file formats of symbian are completely different from those of Android and iOS.
 
@@ -34,7 +34,8 @@ There are files as followings in the directory named **_drive_name_:\SportsTrack
 
 - `config.dat`: contains a lot of **personal data**, including _id--name_ lookup tables of user and activity, etc. 
 - `W*.dat`: **track log** files in binary format.  The file formats of **the new and the old versions** are slightly different each other as
-mentioned before.  [A fetched sample file](https://www.elektroda.pl/rtvforum/topic1416097.html) and the converted gpx are in `references/`.
+mentioned before.  [A fetched sample file](https://www.elektroda.pl/rtvforum/topic1416097.html), 
+[another one](https://sourceforge.net/p/gpsbabel/mailman/message/26219411/) and the converted gpx are in `references/`.
 - `R*.dat`: **route** files of **the old version** in binary format.  The file format, though it lacks for timestamps, is very similar to that of 
 track log of the old version NST.
 - `Rec*.tmp`: **temporal track log files** we see on application crash.  More example is needed, yet [a file useful to test was obtained from 

--- a/references/W178218105.gpx
+++ b/references/W178218105.gpx
@@ -1,0 +1,7937 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v2" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www8.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 http://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd" version="1.1" creator="gpx.py -- https://github.com/tkrajina/gpxpy">
+  <metadata>
+    <name>[26.08.2010 18:02]</name>
+    <desc>[Other 1]</desc>
+    <author>
+      <name>176643330</name>
+    </author>
+    <time>2010-08-26T18:02:49.064003+0200</time>
+  </metadata>
+  <trk>
+    <name>[26.08.2010 18:02]</name>
+    <desc>[Total time: 0:12:49.880; Total distance: 0.979 km; Net speed: 4.576 km/h; Start localtime: 2010-08-26T18:02:49.064; Stop localtime: 2010-08-26T18:15:47.565; Real time: 0:12:58.501; Gross speed: 4.525 km/h]</desc>
+    <trkseg>
+      <trkpt lat="47.9183683333" lon="13.1612533333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:02:49.184875Z</time>
+        <name>1</name>
+        <desc>Speed 0.252 km/h Distance 0.0 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918395" lon="13.1612216667">
+        <ele>572.5</ele>
+        <time>2010-08-26T16:02:49.834876Z</time>
+        <name>2</name>
+        <desc>Speed 0.252 km/h Distance 0.004 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183966667" lon="13.1612183333">
+        <ele>572.0</ele>
+        <time>2010-08-26T16:02:50.844876Z</time>
+        <name>3</name>
+        <desc>Speed 0.18 km/h Distance 0.004 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183983333" lon="13.1612166667">
+        <ele>572.0</ele>
+        <time>2010-08-26T16:02:51.834876Z</time>
+        <name>4</name>
+        <desc>Speed 0.18 km/h Distance 0.004 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183983333" lon="13.161215">
+        <ele>572.0</ele>
+        <time>2010-08-26T16:02:52.834876Z</time>
+        <name>5</name>
+        <desc>Speed 0.072 km/h Distance 0.004 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184" lon="13.1612133333">
+        <ele>572.0</ele>
+        <time>2010-08-26T16:02:53.834876Z</time>
+        <name>6</name>
+        <desc>Speed 0.396 km/h Distance 0.005 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184016667" lon="13.1612183333">
+        <ele>572.0</ele>
+        <time>2010-08-26T16:02:54.824876Z</time>
+        <name>7</name>
+        <desc>Speed 1.332 km/h Distance 0.005 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918405" lon="13.1612266667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:02:55.934875Z</time>
+        <name>8</name>
+        <desc>Speed 2.7 km/h Distance 0.006 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184116667" lon="13.1612383333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:02:56.834876Z</time>
+        <name>9</name>
+        <desc>Speed 3.888 km/h Distance 0.007 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.08</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184183333" lon="13.1612483333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:02:57.834876Z</time>
+        <name>10</name>
+        <desc>Speed 3.924 km/h Distance 0.008 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184233333" lon="13.16126">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:02:58.834876Z</time>
+        <name>11</name>
+        <desc>Speed 3.492 km/h Distance 0.009 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184816667" lon="13.16123">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:00.844876Z</time>
+        <name>12</name>
+        <desc>Speed 13.788 km/h Distance 0.016 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185033333" lon="13.16122">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:01.834876Z</time>
+        <name>13</name>
+        <desc>Speed 13.788 km/h Distance 0.018 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91852" lon="13.1612116667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:02.844876Z</time>
+        <name>14</name>
+        <desc>Speed 13.788 km/h Distance 0.02 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185383333" lon="13.1612133333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:03.844876Z</time>
+        <name>15</name>
+        <desc>Speed 7.092 km/h Distance 0.022 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185516667" lon="13.161215">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:04.844876Z</time>
+        <name>16</name>
+        <desc>Speed 7.092 km/h Distance 0.024 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918565" lon="13.1612183333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:05.844876Z</time>
+        <name>17</name>
+        <desc>Speed 7.092 km/h Distance 0.025 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918575" lon="13.1612216667">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:06.824876Z</time>
+        <name>18</name>
+        <desc>Speed 7.092 km/h Distance 0.027 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185833333" lon="13.1612216667">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:07.834876Z</time>
+        <name>19</name>
+        <desc>Speed 7.092 km/h Distance 0.028 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185883333" lon="13.161225">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:08.844876Z</time>
+        <name>20</name>
+        <desc>Speed 7.092 km/h Distance 0.028 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.161255">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:09.834876Z</time>
+        <name>21</name>
+        <desc>Speed 7.092 km/h Distance 0.03 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.161265">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:03:10.844876Z</time>
+        <name>22</name>
+        <desc>Speed 7.092 km/h Distance 0.031 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91861" lon="13.1613416667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:12.844876Z</time>
+        <name>23</name>
+        <desc>Speed 5.436 km/h Distance 0.037 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186166667" lon="13.1613383333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:13.844876Z</time>
+        <name>24</name>
+        <desc>Speed 5.436 km/h Distance 0.038 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186233333" lon="13.1613383333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:14.844876Z</time>
+        <name>25</name>
+        <desc>Speed 4.572 km/h Distance 0.039 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918595" lon="13.161425">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:16.834876Z</time>
+        <name>26</name>
+        <desc>Speed 4.572 km/h Distance 0.046 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918595" lon="13.1614283333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:17.834876Z</time>
+        <name>27</name>
+        <desc>Speed 4.572 km/h Distance 0.046 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186" lon="13.1614183333">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:18.824876Z</time>
+        <name>28</name>
+        <desc>Speed 3.564 km/h Distance 0.047 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.99</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185933333" lon="13.16142">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:03:19.834876Z</time>
+        <name>29</name>
+        <desc>Speed 0.432 km/h Distance 0.048 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91855" lon="13.1614666667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:21.834876Z</time>
+        <name>30</name>
+        <desc>Speed 0.756 km/h Distance 0.054 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185616667" lon="13.1614583333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:22.834876Z</time>
+        <name>31</name>
+        <desc>Speed 3.132 km/h Distance 0.055 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185683333" lon="13.1614516667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:23.844876Z</time>
+        <name>32</name>
+        <desc>Speed 3.312 km/h Distance 0.056 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.92</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185816667" lon="13.161455">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:24.844876Z</time>
+        <name>33</name>
+        <desc>Speed 5.508 km/h Distance 0.058 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.53</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185783333" lon="13.161455">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:25.834876Z</time>
+        <name>34</name>
+        <desc>Speed 0.756 km/h Distance 0.058 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918575" lon="13.16147">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:26.844876Z</time>
+        <name>35</name>
+        <desc>Speed 0.756 km/h Distance 0.059 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185766667" lon="13.161485">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:27.834876Z</time>
+        <name>36</name>
+        <desc>Speed 0.108 km/h Distance 0.061 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185733333" lon="13.161495">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:28.844876Z</time>
+        <name>37</name>
+        <desc>Speed 0.18 km/h Distance 0.061 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91857" lon="13.161495">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:29.844876Z</time>
+        <name>38</name>
+        <desc>Speed 0.54 km/h Distance 0.062 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185683333" lon="13.1614966667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:30.844876Z</time>
+        <name>39</name>
+        <desc>Speed 0.828 km/h Distance 0.062 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185633333" lon="13.1614966667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:31.844876Z</time>
+        <name>40</name>
+        <desc>Speed 2.304 km/h Distance 0.062 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91856" lon="13.161495">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:32.844876Z</time>
+        <name>41</name>
+        <desc>Speed 2.304 km/h Distance 0.063 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91856" lon="13.161495">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:33.834876Z</time>
+        <name>42</name>
+        <desc>Speed 2.304 km/h Distance 0.063 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185566667" lon="13.1614866667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:34.834876Z</time>
+        <name>43</name>
+        <desc>Speed 2.304 km/h Distance 0.064 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185733333" lon="13.1614733333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:35.844876Z</time>
+        <name>44</name>
+        <desc>Speed 1.692 km/h Distance 0.066 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.1614566667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:36.834876Z</time>
+        <name>45</name>
+        <desc>Speed 1.692 km/h Distance 0.068 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186016667" lon="13.1614533333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:37.844876Z</time>
+        <name>46</name>
+        <desc>Speed 1.692 km/h Distance 0.069 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91859" lon="13.1614316667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:38.834876Z</time>
+        <name>47</name>
+        <desc>Speed 1.692 km/h Distance 0.071 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91859" lon="13.1614266667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:39.834876Z</time>
+        <name>48</name>
+        <desc>Speed 1.692 km/h Distance 0.072 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185933333" lon="13.16143">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:40.834876Z</time>
+        <name>49</name>
+        <desc>Speed 1.692 km/h Distance 0.072 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186166667" lon="13.1614666667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:42.834876Z</time>
+        <name>50</name>
+        <desc>Speed 1.692 km/h Distance 0.076 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186216667" lon="13.1614483333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:43.824876Z</time>
+        <name>51</name>
+        <desc>Speed 0.18 km/h Distance 0.077 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918625" lon="13.1614466667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:44.834876Z</time>
+        <name>52</name>
+        <desc>Speed 0.18 km/h Distance 0.078 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918625" lon="13.1614433333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:45.834876Z</time>
+        <name>53</name>
+        <desc>Speed 0.18 km/h Distance 0.078 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91857" lon="13.16146">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:47.834876Z</time>
+        <name>54</name>
+        <desc>Speed 0.9 km/h Distance 0.084 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91856" lon="13.1614666667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:48.844876Z</time>
+        <name>55</name>
+        <desc>Speed 0.9 km/h Distance 0.086 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185566667" lon="13.1614683333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:49.834876Z</time>
+        <name>56</name>
+        <desc>Speed 0.9 km/h Distance 0.086 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918555" lon="13.16147">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:50.834876Z</time>
+        <name>57</name>
+        <desc>Speed 0.9 km/h Distance 0.086 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918565" lon="13.16146">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:51.834876Z</time>
+        <name>58</name>
+        <desc>Speed 2.736 km/h Distance 0.088 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185783333" lon="13.161465">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:52.834876Z</time>
+        <name>59</name>
+        <desc>Speed 2.736 km/h Distance 0.089 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.1614666667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:53.834876Z</time>
+        <name>60</name>
+        <desc>Speed 2.736 km/h Distance 0.09 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185666667" lon="13.16148">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:55.844876Z</time>
+        <name>61</name>
+        <desc>Speed 2.016 km/h Distance 0.092 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185683333" lon="13.161475">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:56.834876Z</time>
+        <name>62</name>
+        <desc>Speed 2.016 km/h Distance 0.093 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185733333" lon="13.1614733333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:57.834876Z</time>
+        <name>63</name>
+        <desc>Speed 2.016 km/h Distance 0.093 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185616667" lon="13.1614883333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:03:59.834876Z</time>
+        <name>64</name>
+        <desc>Speed 2.988 km/h Distance 0.095 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91857" lon="13.1614866667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:00.834876Z</time>
+        <name>65</name>
+        <desc>Speed 2.988 km/h Distance 0.096 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918575" lon="13.161485">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:01.834876Z</time>
+        <name>66</name>
+        <desc>Speed 2.988 km/h Distance 0.097 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185733333" lon="13.16149">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:02.844876Z</time>
+        <name>67</name>
+        <desc>Speed 0.324 km/h Distance 0.097 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91858" lon="13.16149">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:03.824876Z</time>
+        <name>68</name>
+        <desc>Speed 0.396 km/h Distance 0.098 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185833333" lon="13.1614866667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:04.824876Z</time>
+        <name>69</name>
+        <desc>Speed 0.36 km/h Distance 0.098 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.161485">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:05.824876Z</time>
+        <name>70</name>
+        <desc>Speed 0.36 km/h Distance 0.099 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91859" lon="13.16148">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:06.824876Z</time>
+        <name>71</name>
+        <desc>Speed 0.54 km/h Distance 0.099 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185983333" lon="13.1614733333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:07.824876Z</time>
+        <name>72</name>
+        <desc>Speed 2.088 km/h Distance 0.1 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.58</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186" lon="13.161475">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:08.824876Z</time>
+        <name>73</name>
+        <desc>Speed 2.016 km/h Distance 0.1 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185983333" lon="13.1614766667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:09.844876Z</time>
+        <name>74</name>
+        <desc>Speed 1.188 km/h Distance 0.101 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185983333" lon="13.161475">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:10.844876Z</time>
+        <name>75</name>
+        <desc>Speed 2.196 km/h Distance 0.101 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186016667" lon="13.1614733333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:11.844876Z</time>
+        <name>76</name>
+        <desc>Speed 2.304 km/h Distance 0.101 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186" lon="13.1614716667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:12.844876Z</time>
+        <name>77</name>
+        <desc>Speed 0.612 km/h Distance 0.101 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186016667" lon="13.1614683333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:13.844876Z</time>
+        <name>78</name>
+        <desc>Speed 1.296 km/h Distance 0.102 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186033333" lon="13.16146">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:14.844876Z</time>
+        <name>79</name>
+        <desc>Speed 0.9 km/h Distance 0.102 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185966667" lon="13.161445">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:15.844876Z</time>
+        <name>80</name>
+        <desc>Speed 3.6 km/h Distance 0.104 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185916667" lon="13.1614283333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:16.844876Z</time>
+        <name>81</name>
+        <desc>Speed 3.96 km/h Distance 0.105 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185633333" lon="13.161335">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:19.847000Z</time>
+        <name>82</name>
+        <desc>Speed 20.196 km/h Distance 0.113 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185783333" lon="13.1613183333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:22.844002Z</time>
+        <name>83</name>
+        <desc>Speed 0.108 km/h Distance 0.115 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185816667" lon="13.16131">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:23.844002Z</time>
+        <name>84</name>
+        <desc>Speed 0.36 km/h Distance 0.116 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185866667" lon="13.1613033333">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:24.844002Z</time>
+        <name>85</name>
+        <desc>Speed 1.224 km/h Distance 0.116 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91859" lon="13.1612916667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:25.824002Z</time>
+        <name>86</name>
+        <desc>Speed 0.9 km/h Distance 0.117 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186216667" lon="13.161315">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:27.844002Z</time>
+        <name>87</name>
+        <desc>Speed 7.2 km/h Distance 0.121 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186216667" lon="13.1613016667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:28.834002Z</time>
+        <name>88</name>
+        <desc>Speed 2.088 km/h Distance 0.122 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.58</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186183333" lon="13.1612866667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:29.834002Z</time>
+        <name>89</name>
+        <desc>Speed 0.828 km/h Distance 0.123 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186133333" lon="13.161275">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:30.844002Z</time>
+        <name>90</name>
+        <desc>Speed 0.18 km/h Distance 0.124 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186083333" lon="13.1612666667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:31.844002Z</time>
+        <name>91</name>
+        <desc>Speed 2.952 km/h Distance 0.125 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.82</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186016667" lon="13.1612416667">
+        <ele>571.0</ele>
+        <time>2010-08-26T16:04:32.844002Z</time>
+        <name>92</name>
+        <desc>Speed 1.8 km/h Distance 0.127 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186033333" lon="13.1612266667">
+        <ele>571.5</ele>
+        <time>2010-08-26T16:04:33.844002Z</time>
+        <name>93</name>
+        <desc>Speed 1.584 km/h Distance 0.128 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186116667" lon="13.16121">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:34.844002Z</time>
+        <name>94</name>
+        <desc>Speed 3.78 km/h Distance 0.13 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186183333" lon="13.16121">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:35.844002Z</time>
+        <name>95</name>
+        <desc>Speed 0.72 km/h Distance 0.131 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186233333" lon="13.1612066667">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:36.844002Z</time>
+        <name>96</name>
+        <desc>Speed 0.252 km/h Distance 0.131 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186266667" lon="13.161205">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:37.844002Z</time>
+        <name>97</name>
+        <desc>Speed 0.18 km/h Distance 0.132 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91863" lon="13.1612033333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:38.844002Z</time>
+        <name>98</name>
+        <desc>Speed 0.18 km/h Distance 0.132 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186333333" lon="13.1612033333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:39.844002Z</time>
+        <name>99</name>
+        <desc>Speed 0.072 km/h Distance 0.132 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918635" lon="13.161205">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:40.844002Z</time>
+        <name>100</name>
+        <desc>Speed 0.108 km/h Distance 0.133 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1612083333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:41.844002Z</time>
+        <name>101</name>
+        <desc>Speed 0.18 km/h Distance 0.133 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1612083333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:42.854002Z</time>
+        <name>102</name>
+        <desc>Speed 0.252 km/h Distance 0.133 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186416667" lon="13.16121">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:43.844002Z</time>
+        <name>103</name>
+        <desc>Speed 0.18 km/h Distance 0.133 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186433333" lon="13.1612116667">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:44.844002Z</time>
+        <name>104</name>
+        <desc>Speed 0.072 km/h Distance 0.134 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918645" lon="13.1612133333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:45.844002Z</time>
+        <name>105</name>
+        <desc>Speed 0.36 km/h Distance 0.134 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186516667" lon="13.1612283333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:46.844002Z</time>
+        <name>106</name>
+        <desc>Speed 2.376 km/h Distance 0.135 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.66</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186466667" lon="13.1612433333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:47.844002Z</time>
+        <name>107</name>
+        <desc>Speed 4.5 km/h Distance 0.136 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186433333" lon="13.1612583333">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:48.834002Z</time>
+        <name>108</name>
+        <desc>Speed 3.852 km/h Distance 0.138 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186416667" lon="13.161275">
+        <ele>570.5</ele>
+        <time>2010-08-26T16:04:49.844002Z</time>
+        <name>109</name>
+        <desc>Speed 4.5 km/h Distance 0.139 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1612866667">
+        <ele>570.0</ele>
+        <time>2010-08-26T16:04:50.844002Z</time>
+        <name>110</name>
+        <desc>Speed 3.744 km/h Distance 0.14 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.04</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91863" lon="13.1612933333">
+        <ele>570.0</ele>
+        <time>2010-08-26T16:04:51.844002Z</time>
+        <name>111</name>
+        <desc>Speed 5.04 km/h Distance 0.141 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186216667" lon="13.1613033333">
+        <ele>570.0</ele>
+        <time>2010-08-26T16:04:52.834002Z</time>
+        <name>112</name>
+        <desc>Speed 4.14 km/h Distance 0.142 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186133333" lon="13.1613133333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:04:53.834002Z</time>
+        <name>113</name>
+        <desc>Speed 4.932 km/h Distance 0.143 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918605" lon="13.161325">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:04:54.834002Z</time>
+        <name>114</name>
+        <desc>Speed 5.04 km/h Distance 0.145 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918605" lon="13.1613383333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:04:55.834002Z</time>
+        <name>115</name>
+        <desc>Speed 4.14 km/h Distance 0.146 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186016667" lon="13.161355">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:04:56.834002Z</time>
+        <name>116</name>
+        <desc>Speed 4.32 km/h Distance 0.147 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91861" lon="13.1613666667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:04:57.844002Z</time>
+        <name>117</name>
+        <desc>Speed 3.708 km/h Distance 0.148 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186183333" lon="13.1613783333">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:04:58.834002Z</time>
+        <name>118</name>
+        <desc>Speed 3.708 km/h Distance 0.15 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186283333" lon="13.161395">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:04:59.834002Z</time>
+        <name>119</name>
+        <desc>Speed 3.708 km/h Distance 0.151 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186416667" lon="13.1614166667">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:00.834002Z</time>
+        <name>120</name>
+        <desc>Speed 5.436 km/h Distance 0.153 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186533333" lon="13.161435">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:01.834002Z</time>
+        <name>121</name>
+        <desc>Speed 5.436 km/h Distance 0.155 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186616667" lon="13.16145">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:02.834002Z</time>
+        <name>122</name>
+        <desc>Speed 5.436 km/h Distance 0.157 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91867" lon="13.1614733333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:03.834002Z</time>
+        <name>123</name>
+        <desc>Speed 5.256 km/h Distance 0.159 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186783333" lon="13.1614933333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:04.834002Z</time>
+        <name>124</name>
+        <desc>Speed 5.256 km/h Distance 0.16 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186983333" lon="13.1615033333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:05.834002Z</time>
+        <name>125</name>
+        <desc>Speed 5.256 km/h Distance 0.163 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187116667" lon="13.1615183333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:06.834002Z</time>
+        <name>126</name>
+        <desc>Speed 5.04 km/h Distance 0.165 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187183333" lon="13.1615333333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:07.844002Z</time>
+        <name>127</name>
+        <desc>Speed 4.896 km/h Distance 0.166 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918725" lon="13.1615533333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:08.844002Z</time>
+        <name>128</name>
+        <desc>Speed 5.472 km/h Distance 0.168 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187333333" lon="13.1615716667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:09.844002Z</time>
+        <name>129</name>
+        <desc>Speed 5.796 km/h Distance 0.169 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918735" lon="13.1615933333">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:10.844002Z</time>
+        <name>130</name>
+        <desc>Speed 5.004 km/h Distance 0.171 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187416667" lon="13.1616116667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:11.844002Z</time>
+        <name>131</name>
+        <desc>Speed 5.4 km/h Distance 0.173 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187466667" lon="13.16163">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:12.844002Z</time>
+        <name>132</name>
+        <desc>Speed 5.004 km/h Distance 0.174 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187533333" lon="13.161645">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:13.834002Z</time>
+        <name>133</name>
+        <desc>Speed 4.932 km/h Distance 0.175 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918765" lon="13.161655">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:14.834002Z</time>
+        <name>134</name>
+        <desc>Speed 5.184 km/h Distance 0.177 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187716667" lon="13.1616716667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:15.844002Z</time>
+        <name>135</name>
+        <desc>Speed 4.932 km/h Distance 0.178 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187833333" lon="13.16168">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:16.844002Z</time>
+        <name>136</name>
+        <desc>Speed 5.004 km/h Distance 0.18 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187916667" lon="13.161695">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:17.834002Z</time>
+        <name>137</name>
+        <desc>Speed 4.932 km/h Distance 0.181 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188" lon="13.1617066667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:18.844002Z</time>
+        <name>138</name>
+        <desc>Speed 4.356 km/h Distance 0.182 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188066667" lon="13.161715">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:19.844002Z</time>
+        <name>139</name>
+        <desc>Speed 4.356 km/h Distance 0.183 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918815" lon="13.1617316667">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:20.834002Z</time>
+        <name>140</name>
+        <desc>Speed 4.824 km/h Distance 0.185 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188116667" lon="13.1617583333">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:21.834002Z</time>
+        <name>141</name>
+        <desc>Speed 4.824 km/h Distance 0.187 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91886" lon="13.1617616667">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:23.844002Z</time>
+        <name>142</name>
+        <desc>Speed 4.68 km/h Distance 0.192 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188716667" lon="13.1617733333">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:24.844002Z</time>
+        <name>143</name>
+        <desc>Speed 4.068 km/h Distance 0.194 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91888" lon="13.1617866667">
+        <ele>569.5</ele>
+        <time>2010-08-26T16:05:25.844002Z</time>
+        <name>144</name>
+        <desc>Speed 3.708 km/h Distance 0.195 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188433333" lon="13.1618766667">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:27.844002Z</time>
+        <name>145</name>
+        <desc>Speed 5.112 km/h Distance 0.203 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.42</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188316667" lon="13.161915">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:28.844002Z</time>
+        <name>146</name>
+        <desc>Speed 5.436 km/h Distance 0.206 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188183333" lon="13.1619516667">
+        <ele>569.0</ele>
+        <time>2010-08-26T16:05:29.834002Z</time>
+        <name>147</name>
+        <desc>Speed 4.824 km/h Distance 0.209 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188266667" lon="13.1619716667">
+        <ele>568.5</ele>
+        <time>2010-08-26T16:05:30.844002Z</time>
+        <name>148</name>
+        <desc>Speed 6.408 km/h Distance 0.211 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.78</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91883" lon="13.1619883333">
+        <ele>568.5</ele>
+        <time>2010-08-26T16:05:31.834002Z</time>
+        <name>149</name>
+        <desc>Speed 4.572 km/h Distance 0.212 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188266667" lon="13.1620083333">
+        <ele>568.5</ele>
+        <time>2010-08-26T16:05:32.834002Z</time>
+        <name>150</name>
+        <desc>Speed 4.752 km/h Distance 0.214 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188283333" lon="13.1620316667">
+        <ele>568.5</ele>
+        <time>2010-08-26T16:05:33.834002Z</time>
+        <name>151</name>
+        <desc>Speed 5.904 km/h Distance 0.216 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188316667" lon="13.1620516667">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:34.834002Z</time>
+        <name>152</name>
+        <desc>Speed 5.436 km/h Distance 0.217 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188316667" lon="13.162075">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:35.834002Z</time>
+        <name>153</name>
+        <desc>Speed 5.868 km/h Distance 0.219 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.63</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188366667" lon="13.162095">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:36.834002Z</time>
+        <name>154</name>
+        <desc>Speed 5.796 km/h Distance 0.221 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91884" lon="13.1621116667">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:37.834002Z</time>
+        <name>155</name>
+        <desc>Speed 4.752 km/h Distance 0.222 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918845" lon="13.1621283333">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:38.834002Z</time>
+        <name>156</name>
+        <desc>Speed 4.932 km/h Distance 0.223 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188516667" lon="13.1621433333">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:39.844002Z</time>
+        <name>157</name>
+        <desc>Speed 5.328 km/h Distance 0.225 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.48</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188566667" lon="13.1621616667">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:40.834002Z</time>
+        <name>158</name>
+        <desc>Speed 5.328 km/h Distance 0.226 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.48</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91886" lon="13.16218">
+        <ele>568.0</ele>
+        <time>2010-08-26T16:05:41.834002Z</time>
+        <name>159</name>
+        <desc>Speed 4.68 km/h Distance 0.228 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188666667" lon="13.1621966667">
+        <ele>567.5</ele>
+        <time>2010-08-26T16:05:42.854002Z</time>
+        <name>160</name>
+        <desc>Speed 4.968 km/h Distance 0.229 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91887" lon="13.1622166667">
+        <ele>567.0</ele>
+        <time>2010-08-26T16:05:43.844002Z</time>
+        <name>161</name>
+        <desc>Speed 5.4 km/h Distance 0.23 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188766667" lon="13.1622366667">
+        <ele>566.5</ele>
+        <time>2010-08-26T16:05:44.834002Z</time>
+        <name>162</name>
+        <desc>Speed 5.472 km/h Distance 0.232 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188833333" lon="13.1622566667">
+        <ele>566.0</ele>
+        <time>2010-08-26T16:05:45.834002Z</time>
+        <name>163</name>
+        <desc>Speed 5.796 km/h Distance 0.234 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918895" lon="13.162275">
+        <ele>565.0</ele>
+        <time>2010-08-26T16:05:46.834002Z</time>
+        <name>164</name>
+        <desc>Speed 5.724 km/h Distance 0.236 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.59</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188983333" lon="13.162295">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:05:47.834002Z</time>
+        <name>165</name>
+        <desc>Speed 4.752 km/h Distance 0.237 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188983333" lon="13.1623166667">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:05:48.834002Z</time>
+        <name>166</name>
+        <desc>Speed 4.932 km/h Distance 0.239 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189033333" lon="13.1623366667">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:05:49.834002Z</time>
+        <name>167</name>
+        <desc>Speed 4.932 km/h Distance 0.24 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189116667" lon="13.1623533333">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:05:50.834002Z</time>
+        <name>168</name>
+        <desc>Speed 5.328 km/h Distance 0.242 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.48</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189166667" lon="13.1623683333">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:05:51.834002Z</time>
+        <name>169</name>
+        <desc>Speed 4.32 km/h Distance 0.243 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189233333" lon="13.1623866667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:52.834002Z</time>
+        <name>170</name>
+        <desc>Speed 4.932 km/h Distance 0.245 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91893" lon="13.1624066667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:53.834002Z</time>
+        <name>171</name>
+        <desc>Speed 5.184 km/h Distance 0.246 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189333333" lon="13.162425">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:54.834002Z</time>
+        <name>172</name>
+        <desc>Speed 4.68 km/h Distance 0.248 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91894" lon="13.1624433333">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:55.834002Z</time>
+        <name>173</name>
+        <desc>Speed 5.22 km/h Distance 0.249 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.45</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189466667" lon="13.16246">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:56.834002Z</time>
+        <name>174</name>
+        <desc>Speed 4.968 km/h Distance 0.251 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189516667" lon="13.162475">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:57.834002Z</time>
+        <name>175</name>
+        <desc>Speed 4.14 km/h Distance 0.252 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189583333" lon="13.1624866667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:05:58.834002Z</time>
+        <name>176</name>
+        <desc>Speed 3.78 km/h Distance 0.253 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189683333" lon="13.162485">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:05:59.834002Z</time>
+        <name>177</name>
+        <desc>Speed 3.204 km/h Distance 0.254 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.89</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189766667" lon="13.16249">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:06:00.834002Z</time>
+        <name>178</name>
+        <desc>Speed 3.6 km/h Distance 0.255 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189833333" lon="13.1625016667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:06:01.834002Z</time>
+        <name>179</name>
+        <desc>Speed 3.996 km/h Distance 0.257 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189883333" lon="13.1625166667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:06:02.824002Z</time>
+        <name>180</name>
+        <desc>Speed 4.176 km/h Distance 0.258 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189933333" lon="13.16253">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:06:03.834002Z</time>
+        <name>181</name>
+        <desc>Speed 3.924 km/h Distance 0.259 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190016667" lon="13.162545">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:04.834002Z</time>
+        <name>182</name>
+        <desc>Speed 4.536 km/h Distance 0.26 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919005" lon="13.16256">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:05.834002Z</time>
+        <name>183</name>
+        <desc>Speed 3.672 km/h Distance 0.262 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190083333" lon="13.1625766667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:06.834002Z</time>
+        <name>184</name>
+        <desc>Speed 4.032 km/h Distance 0.263 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91901" lon="13.1626016667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:07.834002Z</time>
+        <name>185</name>
+        <desc>Speed 5.688 km/h Distance 0.265 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.58</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190116667" lon="13.1626266667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:08.834002Z</time>
+        <name>186</name>
+        <desc>Speed 6.264 km/h Distance 0.267 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.74</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190083333" lon="13.162655">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:09.834002Z</time>
+        <name>187</name>
+        <desc>Speed 5.832 km/h Distance 0.269 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190033333" lon="13.1626833333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:10.824002Z</time>
+        <name>188</name>
+        <desc>Speed 5.832 km/h Distance 0.271 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189933333" lon="13.1627116667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:11.834002Z</time>
+        <name>189</name>
+        <desc>Speed 5.832 km/h Distance 0.273 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189983333" lon="13.1627316667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:12.834002Z</time>
+        <name>190</name>
+        <desc>Speed 5.832 km/h Distance 0.275 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918995" lon="13.1627516667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:13.844002Z</time>
+        <name>191</name>
+        <desc>Speed 5.832 km/h Distance 0.276 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189916667" lon="13.16277">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:14.834002Z</time>
+        <name>192</name>
+        <desc>Speed 5.832 km/h Distance 0.278 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91899" lon="13.16278">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:15.814002Z</time>
+        <name>193</name>
+        <desc>Speed 5.832 km/h Distance 0.279 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190166667" lon="13.1627833333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:16.834002Z</time>
+        <name>194</name>
+        <desc>Speed 5.832 km/h Distance 0.282 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91902" lon="13.16279">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:17.934002Z</time>
+        <name>195</name>
+        <desc>Speed 2.736 km/h Distance 0.282 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190183333" lon="13.1628166667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:18.834002Z</time>
+        <name>196</name>
+        <desc>Speed 6.444 km/h Distance 0.284 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.79</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190183333" lon="13.1628133333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:19.844002Z</time>
+        <name>197</name>
+        <desc>Speed 1.224 km/h Distance 0.285 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91901" lon="13.1628283333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:20.834002Z</time>
+        <name>198</name>
+        <desc>Speed 3.528 km/h Distance 0.286 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919" lon="13.1628483333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:21.834002Z</time>
+        <name>199</name>
+        <desc>Speed 4.428 km/h Distance 0.288 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189933333" lon="13.1628633333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:22.834002Z</time>
+        <name>200</name>
+        <desc>Speed 4.5 km/h Distance 0.289 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918985" lon="13.1628716667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:23.834002Z</time>
+        <name>201</name>
+        <desc>Speed 5.652 km/h Distance 0.29 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.57</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189733333" lon="13.16288">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:24.844002Z</time>
+        <name>202</name>
+        <desc>Speed 5.292 km/h Distance 0.292 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189683333" lon="13.16289">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:25.834002Z</time>
+        <name>203</name>
+        <desc>Speed 2.916 km/h Distance 0.293 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.81</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189616667" lon="13.1629033333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:26.834002Z</time>
+        <name>204</name>
+        <desc>Speed 4.32 km/h Distance 0.294 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189516667" lon="13.1629216667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:27.834002Z</time>
+        <name>205</name>
+        <desc>Speed 5.292 km/h Distance 0.296 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189416667" lon="13.16294">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:06:28.834002Z</time>
+        <name>206</name>
+        <desc>Speed 5.004 km/h Distance 0.297 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189283333" lon="13.1629533333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:29.834002Z</time>
+        <name>207</name>
+        <desc>Speed 5.076 km/h Distance 0.299 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189166667" lon="13.16297">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:30.834002Z</time>
+        <name>208</name>
+        <desc>Speed 4.536 km/h Distance 0.301 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189083333" lon="13.162985">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:31.834002Z</time>
+        <name>209</name>
+        <desc>Speed 4.572 km/h Distance 0.302 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188983333" lon="13.1629983333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:32.824002Z</time>
+        <name>210</name>
+        <desc>Speed 4.392 km/h Distance 0.304 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91886" lon="13.1629816667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:34.834002Z</time>
+        <name>211</name>
+        <desc>Speed 4.68 km/h Distance 0.308 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188533333" lon="13.1629883333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:35.844002Z</time>
+        <name>212</name>
+        <desc>Speed 4.14 km/h Distance 0.309 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188433333" lon="13.1629966667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:36.834002Z</time>
+        <name>213</name>
+        <desc>Speed 4.752 km/h Distance 0.311 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1630033333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:06:37.834002Z</time>
+        <name>214</name>
+        <desc>Speed 4.896 km/h Distance 0.312 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188233333" lon="13.1630116667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:06:38.834002Z</time>
+        <name>215</name>
+        <desc>Speed 4.572 km/h Distance 0.313 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187733333" lon="13.1629816667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:06:40.834002Z</time>
+        <name>216</name>
+        <desc>Speed 8.568 km/h Distance 0.319 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187633333" lon="13.1629883333">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:41.834002Z</time>
+        <name>217</name>
+        <desc>Speed 6.156 km/h Distance 0.32 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.71</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918755" lon="13.162995">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:42.844002Z</time>
+        <name>218</name>
+        <desc>Speed 3.852 km/h Distance 0.321 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187466667" lon="13.1630016667">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:43.834002Z</time>
+        <name>219</name>
+        <desc>Speed 4.608 km/h Distance 0.322 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187383333" lon="13.1630133333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:44.834002Z</time>
+        <name>220</name>
+        <desc>Speed 4.68 km/h Distance 0.324 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187316667" lon="13.1630233333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:45.844002Z</time>
+        <name>221</name>
+        <desc>Speed 4.032 km/h Distance 0.325 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918725" lon="13.163035">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:46.844002Z</time>
+        <name>222</name>
+        <desc>Speed 4.5 km/h Distance 0.326 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187116667" lon="13.1630433333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:47.834002Z</time>
+        <name>223</name>
+        <desc>Speed 5.22 km/h Distance 0.327 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.45</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187" lon="13.1630466667">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:48.834002Z</time>
+        <name>224</name>
+        <desc>Speed 4.932 km/h Distance 0.329 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186833333" lon="13.1630466667">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:06:49.834002Z</time>
+        <name>225</name>
+        <desc>Speed 6.552 km/h Distance 0.331 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.82</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186716667" lon="13.163055">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:06:50.834002Z</time>
+        <name>226</name>
+        <desc>Speed 5.004 km/h Distance 0.332 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186633333" lon="13.163065">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:06:51.834002Z</time>
+        <name>227</name>
+        <desc>Speed 4.572 km/h Distance 0.333 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918645" lon="13.1630733333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:52.834002Z</time>
+        <name>228</name>
+        <desc>Speed 7.884 km/h Distance 0.335 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.19</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918645" lon="13.163095">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:53.834002Z</time>
+        <name>229</name>
+        <desc>Speed 5.472 km/h Distance 0.337 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186416667" lon="13.1631033333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:54.834002Z</time>
+        <name>230</name>
+        <desc>Speed 2.7 km/h Distance 0.338 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186383333" lon="13.16311">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:55.844002Z</time>
+        <name>231</name>
+        <desc>Speed 2.304 km/h Distance 0.338 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186383333" lon="13.1631233333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:06:56.834002Z</time>
+        <name>232</name>
+        <desc>Speed 3.132 km/h Distance 0.339 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186383333" lon="13.1631416667">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:57.834002Z</time>
+        <name>233</name>
+        <desc>Speed 3.78 km/h Distance 0.341 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1631583333">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:58.834002Z</time>
+        <name>234</name>
+        <desc>Speed 3.348 km/h Distance 0.342 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186516667" lon="13.1631666667">
+        <ele>563.5</ele>
+        <time>2010-08-26T16:06:59.834002Z</time>
+        <name>235</name>
+        <desc>Speed 3.096 km/h Distance 0.343 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.86</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186566667" lon="13.16319">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:07:00.834002Z</time>
+        <name>236</name>
+        <desc>Speed 3.564 km/h Distance 0.345 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.99</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186583333" lon="13.1632133333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:07:01.834002Z</time>
+        <name>237</name>
+        <desc>Speed 3.852 km/h Distance 0.347 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186533333" lon="13.163235">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:07:02.834002Z</time>
+        <name>238</name>
+        <desc>Speed 3.492 km/h Distance 0.349 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91865" lon="13.1632483333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:07:03.834002Z</time>
+        <name>239</name>
+        <desc>Speed 3.492 km/h Distance 0.35 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186433333" lon="13.1632666667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:07:04.834002Z</time>
+        <name>240</name>
+        <desc>Speed 4.212 km/h Distance 0.351 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1632866667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:07:05.834002Z</time>
+        <name>241</name>
+        <desc>Speed 3.888 km/h Distance 0.353 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.08</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186383333" lon="13.1633066667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:07:06.834002Z</time>
+        <name>242</name>
+        <desc>Speed 3.6 km/h Distance 0.354 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91864" lon="13.1633233333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:07:07.834002Z</time>
+        <name>243</name>
+        <desc>Speed 4.5 km/h Distance 0.356 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918645" lon="13.16334">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:07:08.834002Z</time>
+        <name>244</name>
+        <desc>Speed 4.428 km/h Distance 0.357 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91865" lon="13.1633566667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:07:09.834002Z</time>
+        <name>245</name>
+        <desc>Speed 4.392 km/h Distance 0.358 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91866" lon="13.163365">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:07:10.834002Z</time>
+        <name>246</name>
+        <desc>Speed 4.284 km/h Distance 0.36 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.19</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186716667" lon="13.16336">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:11.834002Z</time>
+        <name>247</name>
+        <desc>Speed 4.896 km/h Distance 0.361 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91868" lon="13.163355">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:12.834002Z</time>
+        <name>248</name>
+        <desc>Speed 4.896 km/h Distance 0.362 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918685" lon="13.1633533333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:13.834002Z</time>
+        <name>249</name>
+        <desc>Speed 4.896 km/h Distance 0.363 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91869" lon="13.16335">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:14.844002Z</time>
+        <name>250</name>
+        <desc>Speed 4.896 km/h Distance 0.363 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918695" lon="13.1633483333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:15.834002Z</time>
+        <name>251</name>
+        <desc>Speed 4.896 km/h Distance 0.364 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186983333" lon="13.1633466667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:16.824002Z</time>
+        <name>252</name>
+        <desc>Speed 4.896 km/h Distance 0.364 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187016667" lon="13.163345">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:17.814002Z</time>
+        <name>253</name>
+        <desc>Speed 4.896 km/h Distance 0.365 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187033333" lon="13.163345">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:18.814002Z</time>
+        <name>254</name>
+        <desc>Speed 4.896 km/h Distance 0.365 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187066667" lon="13.1633433333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:19.814002Z</time>
+        <name>255</name>
+        <desc>Speed 4.896 km/h Distance 0.365 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185316667" lon="13.1632816667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:43.830872Z</time>
+        <name>256</name>
+        <desc>Speed 4.896 km/h Distance 0.385 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184333333" lon="13.1631483333">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:07:46.831001Z</time>
+        <name>257</name>
+        <desc>Speed 4.896 km/h Distance 0.4 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918435" lon="13.163155">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:07:47.841001Z</time>
+        <name>258</name>
+        <desc>Speed 4.896 km/h Distance 0.4 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918515" lon="13.1633916667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:07:50.836998Z</time>
+        <name>259</name>
+        <desc>Speed 3.492 km/h Distance 0.42 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91853" lon="13.1634116667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:07:51.836998Z</time>
+        <name>260</name>
+        <desc>Speed 3.744 km/h Distance 0.422 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.04</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185333333" lon="13.1634266667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:07:52.836998Z</time>
+        <name>261</name>
+        <desc>Speed 5.112 km/h Distance 0.424 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.42</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185333333" lon="13.1634466667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:07:53.836998Z</time>
+        <name>262</name>
+        <desc>Speed 4.572 km/h Distance 0.425 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918535" lon="13.1634633333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:07:54.836998Z</time>
+        <name>263</name>
+        <desc>Speed 3.924 km/h Distance 0.426 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185333333" lon="13.1634816667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:07:55.836998Z</time>
+        <name>264</name>
+        <desc>Speed 3.996 km/h Distance 0.428 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185283333" lon="13.1634933333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:07:56.836998Z</time>
+        <name>265</name>
+        <desc>Speed 3.96 km/h Distance 0.429 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918525" lon="13.1635066667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:07:57.836998Z</time>
+        <name>266</name>
+        <desc>Speed 4.32 km/h Distance 0.43 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185216667" lon="13.1635183333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:07:58.836998Z</time>
+        <name>267</name>
+        <desc>Speed 4.5 km/h Distance 0.431 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91852" lon="13.16353">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:07:59.836998Z</time>
+        <name>268</name>
+        <desc>Speed 3.996 km/h Distance 0.432 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918515" lon="13.1635416667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:00.836998Z</time>
+        <name>269</name>
+        <desc>Speed 4.896 km/h Distance 0.433 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185083333" lon="13.1635533333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:01.906998Z</time>
+        <name>270</name>
+        <desc>Speed 4.068 km/h Distance 0.434 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185" lon="13.1635616667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:02.836998Z</time>
+        <name>271</name>
+        <desc>Speed 4.104 km/h Distance 0.435 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918495" lon="13.1635733333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:03.836998Z</time>
+        <name>272</name>
+        <desc>Speed 3.744 km/h Distance 0.436 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.04</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184916667" lon="13.1635916667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:04.836998Z</time>
+        <name>273</name>
+        <desc>Speed 4.032 km/h Distance 0.437 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184866667" lon="13.163605">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:05.836998Z</time>
+        <name>274</name>
+        <desc>Speed 4.176 km/h Distance 0.439 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91848" lon="13.1636183333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:06.836998Z</time>
+        <name>275</name>
+        <desc>Speed 4.392 km/h Distance 0.44 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184733333" lon="13.1636333333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:07.836998Z</time>
+        <name>276</name>
+        <desc>Speed 4.428 km/h Distance 0.441 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91847" lon="13.1636433333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:08.826998Z</time>
+        <name>277</name>
+        <desc>Speed 3.06 km/h Distance 0.442 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.85</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184133333" lon="13.16367">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:10.836998Z</time>
+        <name>278</name>
+        <desc>Speed 12.96 km/h Distance 0.449 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.6</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918395" lon="13.1636866667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:11.846998Z</time>
+        <name>279</name>
+        <desc>Speed 7.776 km/h Distance 0.451 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183866667" lon="13.1637033333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:12.836998Z</time>
+        <name>280</name>
+        <desc>Speed 4.32 km/h Distance 0.453 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183816667" lon="13.1637166667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:13.826998Z</time>
+        <name>281</name>
+        <desc>Speed 4.608 km/h Distance 0.454 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183733333" lon="13.1637316667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:14.836998Z</time>
+        <name>282</name>
+        <desc>Speed 6.372 km/h Distance 0.455 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.77</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183683333" lon="13.163745">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:15.826998Z</time>
+        <name>283</name>
+        <desc>Speed 3.708 km/h Distance 0.456 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183566667" lon="13.1637633333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:16.836998Z</time>
+        <name>284</name>
+        <desc>Speed 6.84 km/h Distance 0.458 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.9</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183516667" lon="13.1637766667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:17.826998Z</time>
+        <name>285</name>
+        <desc>Speed 5.184 km/h Distance 0.459 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183433333" lon="13.16379">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:18.826998Z</time>
+        <name>286</name>
+        <desc>Speed 5.472 km/h Distance 0.461 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91834" lon="13.163805">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:19.826998Z</time>
+        <name>287</name>
+        <desc>Speed 4.464 km/h Distance 0.462 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.24</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91833" lon="13.1638166667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:20.826998Z</time>
+        <name>288</name>
+        <desc>Speed 4.5 km/h Distance 0.463 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183233333" lon="13.1638266667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:21.836998Z</time>
+        <name>289</name>
+        <desc>Speed 4.5 km/h Distance 0.464 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183116667" lon="13.16384">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:22.836998Z</time>
+        <name>290</name>
+        <desc>Speed 4.932 km/h Distance 0.466 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183033333" lon="13.16385">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:23.836998Z</time>
+        <name>291</name>
+        <desc>Speed 4.932 km/h Distance 0.467 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183" lon="13.1638716667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:08:24.816998Z</time>
+        <name>292</name>
+        <desc>Speed 5.4 km/h Distance 0.469 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918295" lon="13.163885">
+        <ele>556.0</ele>
+        <time>2010-08-26T16:08:25.836998Z</time>
+        <name>293</name>
+        <desc>Speed 3.744 km/h Distance 0.47 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.04</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182866667" lon="13.1638983333">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:08:26.826998Z</time>
+        <name>294</name>
+        <desc>Speed 4.5 km/h Distance 0.471 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918275" lon="13.16391">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:27.836998Z</time>
+        <name>295</name>
+        <desc>Speed 5.4 km/h Distance 0.473 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182633333" lon="13.163915">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:08:28.836998Z</time>
+        <name>296</name>
+        <desc>Speed 5.688 km/h Distance 0.474 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.58</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182533333" lon="13.1639216667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:08:29.836998Z</time>
+        <name>297</name>
+        <desc>Speed 5.76 km/h Distance 0.475 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.6</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182466667" lon="13.1639266667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:08:30.826998Z</time>
+        <name>298</name>
+        <desc>Speed 4.86 km/h Distance 0.476 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.35</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182383333" lon="13.1639316667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:08:31.936998Z</time>
+        <name>299</name>
+        <desc>Speed 5.76 km/h Distance 0.477 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.6</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182383333" lon="13.1639433333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:32.826998Z</time>
+        <name>300</name>
+        <desc>Speed 4.032 km/h Distance 0.478 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182316667" lon="13.1639616667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:33.826998Z</time>
+        <name>301</name>
+        <desc>Speed 5.544 km/h Distance 0.48 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.54</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182266667" lon="13.16397">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:08:34.836998Z</time>
+        <name>302</name>
+        <desc>Speed 3.996 km/h Distance 0.481 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182183333" lon="13.1639783333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:08:35.836998Z</time>
+        <name>303</name>
+        <desc>Speed 4.284 km/h Distance 0.482 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.19</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182133333" lon="13.16399">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:08:36.836998Z</time>
+        <name>304</name>
+        <desc>Speed 3.492 km/h Distance 0.483 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918205" lon="13.164">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:37.836998Z</time>
+        <name>305</name>
+        <desc>Speed 4.68 km/h Distance 0.484 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918195" lon="13.1640116667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:38.836998Z</time>
+        <name>306</name>
+        <desc>Speed 4.428 km/h Distance 0.485 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181866667" lon="13.164025">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:08:39.836998Z</time>
+        <name>307</name>
+        <desc>Speed 4.644 km/h Distance 0.487 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918175" lon="13.1640383333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:40.836998Z</time>
+        <name>308</name>
+        <desc>Speed 5.436 km/h Distance 0.488 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181683333" lon="13.1640666667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:08:41.826998Z</time>
+        <name>309</name>
+        <desc>Speed 8.388 km/h Distance 0.491 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181533333" lon="13.16408">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:08:42.846998Z</time>
+        <name>310</name>
+        <desc>Speed 6.696 km/h Distance 0.492 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.86</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918145" lon="13.1640916667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:08:43.836998Z</time>
+        <name>311</name>
+        <desc>Speed 3.924 km/h Distance 0.494 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181333333" lon="13.1641033333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:08:44.836998Z</time>
+        <name>312</name>
+        <desc>Speed 4.644 km/h Distance 0.495 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181266667" lon="13.1641233333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:08:45.836998Z</time>
+        <name>313</name>
+        <desc>Speed 4.5 km/h Distance 0.497 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181166667" lon="13.1641366667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:08:46.836998Z</time>
+        <name>314</name>
+        <desc>Speed 4.5 km/h Distance 0.498 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918105" lon="13.1641466667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:08:47.846998Z</time>
+        <name>315</name>
+        <desc>Speed 4.428 km/h Distance 0.5 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180966667" lon="13.16417">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:08:48.836998Z</time>
+        <name>316</name>
+        <desc>Speed 6.264 km/h Distance 0.502 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.74</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180866667" lon="13.1641933333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:08:49.836998Z</time>
+        <name>317</name>
+        <desc>Speed 6.84 km/h Distance 0.504 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.9</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180766667" lon="13.164215">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:08:50.836998Z</time>
+        <name>318</name>
+        <desc>Speed 5.832 km/h Distance 0.506 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91806" lon="13.16423">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:08:51.836998Z</time>
+        <name>319</name>
+        <desc>Speed 7.164 km/h Distance 0.508 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.99</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180533333" lon="13.164245">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:08:52.836998Z</time>
+        <name>320</name>
+        <desc>Speed 4.536 km/h Distance 0.509 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180466667" lon="13.16426">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:08:53.836998Z</time>
+        <name>321</name>
+        <desc>Speed 4.392 km/h Distance 0.511 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918045" lon="13.1642716667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:08:54.836998Z</time>
+        <name>322</name>
+        <desc>Speed 2.988 km/h Distance 0.512 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180366667" lon="13.16428">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:08:55.836998Z</time>
+        <name>323</name>
+        <desc>Speed 4.284 km/h Distance 0.513 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.19</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918025" lon="13.164285">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:08:56.836998Z</time>
+        <name>324</name>
+        <desc>Speed 3.996 km/h Distance 0.514 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918015" lon="13.1642883333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:08:57.836998Z</time>
+        <name>325</name>
+        <desc>Speed 4.176 km/h Distance 0.515 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180033333" lon="13.1642883333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:08:58.836998Z</time>
+        <name>326</name>
+        <desc>Speed 4.212 km/h Distance 0.517 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179883333" lon="13.1642816667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:08:59.836998Z</time>
+        <name>327</name>
+        <desc>Speed 6.3 km/h Distance 0.518 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179783333" lon="13.1642866667">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:09:00.826998Z</time>
+        <name>328</name>
+        <desc>Speed 4.824 km/h Distance 0.52 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1642933333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:01.866998Z</time>
+        <name>329</name>
+        <desc>Speed 3.708 km/h Distance 0.52 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917965" lon="13.1642983333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:02.826998Z</time>
+        <name>330</name>
+        <desc>Speed 3.96 km/h Distance 0.521 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917955" lon="13.1643083333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:09:03.836998Z</time>
+        <name>331</name>
+        <desc>Speed 4.32 km/h Distance 0.523 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179466667" lon="13.1643183333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:04.836998Z</time>
+        <name>332</name>
+        <desc>Speed 4.212 km/h Distance 0.524 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179366667" lon="13.164315">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:05.836998Z</time>
+        <name>333</name>
+        <desc>Speed 4.788 km/h Distance 0.525 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179283333" lon="13.1643216667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:06.836998Z</time>
+        <name>334</name>
+        <desc>Speed 3.672 km/h Distance 0.526 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179166667" lon="13.16433">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:07.836998Z</time>
+        <name>335</name>
+        <desc>Speed 4.5 km/h Distance 0.527 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179083333" lon="13.1643366667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:08.836998Z</time>
+        <name>336</name>
+        <desc>Speed 3.6 km/h Distance 0.528 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178966667" lon="13.16435">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:09:09.836998Z</time>
+        <name>337</name>
+        <desc>Speed 5.796 km/h Distance 0.53 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.61</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178866667" lon="13.16436">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:09:10.836998Z</time>
+        <name>338</name>
+        <desc>Speed 3.528 km/h Distance 0.531 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91788" lon="13.16437">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:09:11.836998Z</time>
+        <name>339</name>
+        <desc>Speed 3.564 km/h Distance 0.532 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.99</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91787" lon="13.1643766667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:09:12.836998Z</time>
+        <name>340</name>
+        <desc>Speed 4.176 km/h Distance 0.534 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178616667" lon="13.164385">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:09:13.836998Z</time>
+        <name>341</name>
+        <desc>Speed 3.528 km/h Distance 0.535 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178366667" lon="13.1644066667">
+        <ele>564.5</ele>
+        <time>2010-08-26T16:09:15.836998Z</time>
+        <name>342</name>
+        <desc>Speed 2.7 km/h Distance 0.538 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178316667" lon="13.1644183333">
+        <ele>564.0</ele>
+        <time>2010-08-26T16:09:16.836998Z</time>
+        <name>343</name>
+        <desc>Speed 2.88 km/h Distance 0.539 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.8</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178366667" lon="13.164435">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:09:17.836998Z</time>
+        <name>344</name>
+        <desc>Speed 3.6 km/h Distance 0.54 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917835" lon="13.1644516667">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:09:18.836998Z</time>
+        <name>345</name>
+        <desc>Speed 4.032 km/h Distance 0.542 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178366667" lon="13.16447">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:09:19.836998Z</time>
+        <name>346</name>
+        <desc>Speed 4.464 km/h Distance 0.543 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.24</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178333333" lon="13.164485">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:09:20.836998Z</time>
+        <name>347</name>
+        <desc>Speed 4.032 km/h Distance 0.544 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178216667" lon="13.16451">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:09:21.836998Z</time>
+        <name>348</name>
+        <desc>Speed 8.316 km/h Distance 0.547 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.31</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178333333" lon="13.1645183333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:09:22.836998Z</time>
+        <name>349</name>
+        <desc>Speed 4.932 km/h Distance 0.548 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178383333" lon="13.1645383333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:09:23.836998Z</time>
+        <name>350</name>
+        <desc>Speed 4.968 km/h Distance 0.55 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178416667" lon="13.1645583333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:09:24.836998Z</time>
+        <name>351</name>
+        <desc>Speed 4.932 km/h Distance 0.551 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178416667" lon="13.16458">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:09:25.836998Z</time>
+        <name>352</name>
+        <desc>Speed 4.5 km/h Distance 0.553 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91784" lon="13.1646">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:09:26.836998Z</time>
+        <name>353</name>
+        <desc>Speed 4.032 km/h Distance 0.554 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91784" lon="13.164615">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:09:27.836998Z</time>
+        <name>354</name>
+        <desc>Speed 3.384 km/h Distance 0.555 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.94</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917845" lon="13.1646266667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:09:28.836998Z</time>
+        <name>355</name>
+        <desc>Speed 2.736 km/h Distance 0.556 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178516667" lon="13.1646383333">
+        <ele>555.0</ele>
+        <time>2010-08-26T16:09:29.836998Z</time>
+        <name>356</name>
+        <desc>Speed 3.276 km/h Distance 0.557 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.91</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178616667" lon="13.1646533333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:09:30.836998Z</time>
+        <name>357</name>
+        <desc>Speed 4.176 km/h Distance 0.559 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178733333" lon="13.1646683333">
+        <ele>552.0</ele>
+        <time>2010-08-26T16:09:31.836998Z</time>
+        <name>358</name>
+        <desc>Speed 4.068 km/h Distance 0.561 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178833333" lon="13.1646783333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:09:32.836998Z</time>
+        <name>359</name>
+        <desc>Speed 4.356 km/h Distance 0.562 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178933333" lon="13.1646883333">
+        <ele>550.5</ele>
+        <time>2010-08-26T16:09:33.906998Z</time>
+        <name>360</name>
+        <desc>Speed 3.42 km/h Distance 0.563 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.95</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179066667" lon="13.1647016667">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:09:34.836998Z</time>
+        <name>361</name>
+        <desc>Speed 4.644 km/h Distance 0.565 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917915" lon="13.1647116667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:35.836998Z</time>
+        <name>362</name>
+        <desc>Speed 3.708 km/h Distance 0.566 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179283333" lon="13.1647166667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:36.836998Z</time>
+        <name>363</name>
+        <desc>Speed 4.608 km/h Distance 0.568 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917935" lon="13.1647333333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:37.836998Z</time>
+        <name>364</name>
+        <desc>Speed 4.392 km/h Distance 0.569 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179416667" lon="13.1647466667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:38.836998Z</time>
+        <name>365</name>
+        <desc>Speed 3.312 km/h Distance 0.571 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.92</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91795" lon="13.16476">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:39.836998Z</time>
+        <name>366</name>
+        <desc>Speed 3.564 km/h Distance 0.572 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.99</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179583333" lon="13.1647716667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:40.836998Z</time>
+        <name>367</name>
+        <desc>Speed 4.068 km/h Distance 0.573 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917965" lon="13.164795">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:09:41.836998Z</time>
+        <name>368</name>
+        <desc>Speed 4.032 km/h Distance 0.575 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91797" lon="13.1648133333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:42.856998Z</time>
+        <name>369</name>
+        <desc>Speed 3.348 km/h Distance 0.577 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.1648316667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:09:43.836998Z</time>
+        <name>370</name>
+        <desc>Speed 2.304 km/h Distance 0.578 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.164845">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:09:44.836998Z</time>
+        <name>371</name>
+        <desc>Speed 1.548 km/h Distance 0.579 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.1648483333">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:09:45.836998Z</time>
+        <name>372</name>
+        <desc>Speed 0.18 km/h Distance 0.579 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1648533333">
+        <ele>550.5</ele>
+        <time>2010-08-26T16:09:46.836998Z</time>
+        <name>373</name>
+        <desc>Speed 0.072 km/h Distance 0.58 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179683333" lon="13.1648583333">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:09:47.836998Z</time>
+        <name>374</name>
+        <desc>Speed 0.108 km/h Distance 0.58 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179666667" lon="13.16486">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:09:48.836998Z</time>
+        <name>375</name>
+        <desc>Speed 0.18 km/h Distance 0.58 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179666667" lon="13.1648633333">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:09:49.836998Z</time>
+        <name>376</name>
+        <desc>Speed 0.504 km/h Distance 0.581 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179683333" lon="13.1648666667">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:09:50.836998Z</time>
+        <name>377</name>
+        <desc>Speed 0.18 km/h Distance 0.581 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1648683333">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:09:51.836998Z</time>
+        <name>378</name>
+        <desc>Speed 0.072 km/h Distance 0.581 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1648716667">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:09:52.836998Z</time>
+        <name>379</name>
+        <desc>Speed 0.072 km/h Distance 0.582 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.164875">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:09:53.836998Z</time>
+        <name>380</name>
+        <desc>Speed 0.072 km/h Distance 0.582 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.1648766667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:09:54.836998Z</time>
+        <name>381</name>
+        <desc>Speed 0.18 km/h Distance 0.582 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917975" lon="13.16488">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:09:55.826998Z</time>
+        <name>382</name>
+        <desc>Speed 0.72 km/h Distance 0.582 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.1648833333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:09:56.836998Z</time>
+        <name>383</name>
+        <desc>Speed 0.252 km/h Distance 0.583 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179733333" lon="13.1648866667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:09:57.836998Z</time>
+        <name>384</name>
+        <desc>Speed 0.36 km/h Distance 0.583 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1648883333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:09:58.836998Z</time>
+        <name>385</name>
+        <desc>Speed 0.0 km/h Distance 0.583 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91797" lon="13.1648916667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:09:59.836998Z</time>
+        <name>386</name>
+        <desc>Speed 0.648 km/h Distance 0.584 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.18</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91797" lon="13.1648933333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:00.816998Z</time>
+        <name>387</name>
+        <desc>Speed 0.648 km/h Distance 0.584 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.18</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179716667" lon="13.1648883333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:01.826998Z</time>
+        <name>388</name>
+        <desc>Speed 1.692 km/h Distance 0.584 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179683333" lon="13.1648966667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:02.836998Z</time>
+        <name>389</name>
+        <desc>Speed 1.332 km/h Distance 0.585 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179666667" lon="13.1648933333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:03.836998Z</time>
+        <name>390</name>
+        <desc>Speed 1.8 km/h Distance 0.585 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917965" lon="13.1648966667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:04.836998Z</time>
+        <name>391</name>
+        <desc>Speed 1.476 km/h Distance 0.585 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179616667" lon="13.1648733333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:05.826998Z</time>
+        <name>392</name>
+        <desc>Speed 4.932 km/h Distance 0.587 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179566667" lon="13.16485">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:06.836998Z</time>
+        <name>393</name>
+        <desc>Speed 4.824 km/h Distance 0.589 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179666667" lon="13.16485">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:07.826998Z</time>
+        <name>394</name>
+        <desc>Speed 4.032 km/h Distance 0.59 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179566667" lon="13.1647883333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:09.926998Z</time>
+        <name>395</name>
+        <desc>Speed 5.112 km/h Distance 0.595 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.42</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179483333" lon="13.16478">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:10.826998Z</time>
+        <name>396</name>
+        <desc>Speed 4.104 km/h Distance 0.596 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91794" lon="13.16477">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:11.826998Z</time>
+        <name>397</name>
+        <desc>Speed 3.672 km/h Distance 0.597 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917935" lon="13.1647316667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:12.826998Z</time>
+        <name>398</name>
+        <desc>Speed 2.952 km/h Distance 0.6 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.82</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91793" lon="13.1647216667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:13.816998Z</time>
+        <name>399</name>
+        <desc>Speed 2.736 km/h Distance 0.601 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179283333" lon="13.1647116667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:14.826998Z</time>
+        <name>400</name>
+        <desc>Speed 1.692 km/h Distance 0.602 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179266667" lon="13.1647">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:15.826998Z</time>
+        <name>401</name>
+        <desc>Speed 3.168 km/h Distance 0.603 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.88</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179266667" lon="13.1646916667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:10:16.816998Z</time>
+        <name>402</name>
+        <desc>Speed 3.168 km/h Distance 0.603 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.88</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917925" lon="13.1646833333">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:10:17.816998Z</time>
+        <name>403</name>
+        <desc>Speed 3.384 km/h Distance 0.604 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.94</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179283333" lon="13.1646783333">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:10:18.886998Z</time>
+        <name>404</name>
+        <desc>Speed 2.7 km/h Distance 0.604 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917915" lon="13.1646583333">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:10:19.836998Z</time>
+        <name>405</name>
+        <desc>Speed 9.792 km/h Distance 0.607 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.72</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179116667" lon="13.1646383333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:21.826998Z</time>
+        <name>406</name>
+        <desc>Speed 2.52 km/h Distance 0.608 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.7</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179083333" lon="13.1646316667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:10:22.826998Z</time>
+        <name>407</name>
+        <desc>Speed 2.448 km/h Distance 0.609 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.68</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179066667" lon="13.1646266667">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:10:23.826998Z</time>
+        <name>408</name>
+        <desc>Speed 1.8 km/h Distance 0.609 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179066667" lon="13.1646183333">
+        <ele>552.0</ele>
+        <time>2010-08-26T16:10:24.826998Z</time>
+        <name>409</name>
+        <desc>Speed 2.736 km/h Distance 0.61 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.76</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179016667" lon="13.16461">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:25.836998Z</time>
+        <name>410</name>
+        <desc>Speed 3.672 km/h Distance 0.611 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178966667" lon="13.1646016667">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:26.836998Z</time>
+        <name>411</name>
+        <desc>Speed 2.7 km/h Distance 0.611 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178883333" lon="13.1646033333">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:27.826998Z</time>
+        <name>412</name>
+        <desc>Speed 3.132 km/h Distance 0.612 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91788" lon="13.16459">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:28.836998Z</time>
+        <name>413</name>
+        <desc>Speed 4.968 km/h Distance 0.614 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178716667" lon="13.1645766667">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:29.826998Z</time>
+        <name>414</name>
+        <desc>Speed 2.916 km/h Distance 0.615 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.81</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178633333" lon="13.1645516667">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:30.826998Z</time>
+        <name>415</name>
+        <desc>Speed 6.66 km/h Distance 0.617 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.85</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178566667" lon="13.1645383333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:31.836998Z</time>
+        <name>416</name>
+        <desc>Speed 4.068 km/h Distance 0.618 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917855" lon="13.16453">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:32.826998Z</time>
+        <name>417</name>
+        <desc>Speed 1.872 km/h Distance 0.619 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178516667" lon="13.16451">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:33.836998Z</time>
+        <name>418</name>
+        <desc>Speed 3.312 km/h Distance 0.621 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.92</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91785" lon="13.1644733333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:34.836998Z</time>
+        <name>419</name>
+        <desc>Speed 4.644 km/h Distance 0.623 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178433333" lon="13.164455">
+        <ele>550.5</ele>
+        <time>2010-08-26T16:10:35.846998Z</time>
+        <name>420</name>
+        <desc>Speed 3.204 km/h Distance 0.625 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.89</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178183333" lon="13.1644216667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:10:37.826998Z</time>
+        <name>421</name>
+        <desc>Speed 1.548 km/h Distance 0.629 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178183333" lon="13.1644116667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:10:38.826998Z</time>
+        <name>422</name>
+        <desc>Speed 1.548 km/h Distance 0.629 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178183333" lon="13.1644066667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:10:39.826998Z</time>
+        <name>423</name>
+        <desc>Speed 1.548 km/h Distance 0.63 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91782" lon="13.1644033333">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:10:40.836998Z</time>
+        <name>424</name>
+        <desc>Speed 1.548 km/h Distance 0.63 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178183333" lon="13.1643816667">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:41.826998Z</time>
+        <name>425</name>
+        <desc>Speed 4.176 km/h Distance 0.632 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177966667" lon="13.1643833333">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:42.846998Z</time>
+        <name>426</name>
+        <desc>Speed 8.352 km/h Distance 0.634 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177916667" lon="13.1643716667">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:43.836998Z</time>
+        <name>427</name>
+        <desc>Speed 3.6 km/h Distance 0.635 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917785" lon="13.164365">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:44.836998Z</time>
+        <name>428</name>
+        <desc>Speed 0.828 km/h Distance 0.636 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177833333" lon="13.1643683333">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:45.836998Z</time>
+        <name>429</name>
+        <desc>Speed 2.016 km/h Distance 0.636 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177766667" lon="13.1643783333">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:46.836998Z</time>
+        <name>430</name>
+        <desc>Speed 2.7 km/h Distance 0.637 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177766667" lon="13.16439">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:47.826998Z</time>
+        <name>431</name>
+        <desc>Speed 2.232 km/h Distance 0.638 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917775" lon="13.1644">
+        <ele>549.5</ele>
+        <time>2010-08-26T16:10:48.826998Z</time>
+        <name>432</name>
+        <desc>Speed 1.368 km/h Distance 0.639 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177733333" lon="13.1644066667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:10:49.826998Z</time>
+        <name>433</name>
+        <desc>Speed 2.232 km/h Distance 0.64 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177716667" lon="13.164415">
+        <ele>550.5</ele>
+        <time>2010-08-26T16:10:50.836998Z</time>
+        <name>434</name>
+        <desc>Speed 2.232 km/h Distance 0.64 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177633333" lon="13.1644366667">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:51.826998Z</time>
+        <name>435</name>
+        <desc>Speed 3.6 km/h Distance 0.642 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177733333" lon="13.1644416667">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:52.826998Z</time>
+        <name>436</name>
+        <desc>Speed 5.004 km/h Distance 0.643 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177666667" lon="13.164445">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:53.836998Z</time>
+        <name>437</name>
+        <desc>Speed 0.324 km/h Distance 0.644 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177566667" lon="13.1644466667">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:54.836998Z</time>
+        <name>438</name>
+        <desc>Speed 0.072 km/h Distance 0.645 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177416667" lon="13.1644483333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:55.836998Z</time>
+        <name>439</name>
+        <desc>Speed 0.108 km/h Distance 0.647 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177266667" lon="13.16445">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:56.836998Z</time>
+        <name>440</name>
+        <desc>Speed 0.036 km/h Distance 0.649 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917715" lon="13.16445">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:10:57.836998Z</time>
+        <name>441</name>
+        <desc>Speed 0.252 km/h Distance 0.65 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177066667" lon="13.1644516667">
+        <ele>552.0</ele>
+        <time>2010-08-26T16:10:58.836998Z</time>
+        <name>442</name>
+        <desc>Speed 0.072 km/h Distance 0.651 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917705" lon="13.16445">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:10:59.836998Z</time>
+        <name>443</name>
+        <desc>Speed 0.18 km/h Distance 0.651 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177016667" lon="13.1644483333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:11:00.826998Z</time>
+        <name>444</name>
+        <desc>Speed 0.108 km/h Distance 0.651 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9176983333" lon="13.1644483333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:11:01.826998Z</time>
+        <name>445</name>
+        <desc>Speed 0.036 km/h Distance 0.652 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9176966667" lon="13.1644483333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:11:02.826998Z</time>
+        <name>446</name>
+        <desc>Speed 0.108 km/h Distance 0.652 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917695" lon="13.1644566667">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:03.826998Z</time>
+        <name>447</name>
+        <desc>Speed 1.98 km/h Distance 0.653 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.55</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9176933333" lon="13.1644633333">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:04.836998Z</time>
+        <name>448</name>
+        <desc>Speed 1.98 km/h Distance 0.653 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.55</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9176933333" lon="13.164465">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:05.826998Z</time>
+        <name>449</name>
+        <desc>Speed 1.98 km/h Distance 0.653 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.55</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917695" lon="13.1644683333">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:06.826998Z</time>
+        <name>450</name>
+        <desc>Speed 3.528 km/h Distance 0.654 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177016667" lon="13.16447">
+        <ele>552.0</ele>
+        <time>2010-08-26T16:11:07.826998Z</time>
+        <name>451</name>
+        <desc>Speed 2.304 km/h Distance 0.654 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.64</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91771" lon="13.1644666667">
+        <ele>552.0</ele>
+        <time>2010-08-26T16:11:08.826998Z</time>
+        <name>452</name>
+        <desc>Speed 3.132 km/h Distance 0.655 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177216667" lon="13.16446">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:09.826998Z</time>
+        <name>453</name>
+        <desc>Speed 4.824 km/h Distance 0.657 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177283333" lon="13.1644616667">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:10.826998Z</time>
+        <name>454</name>
+        <desc>Speed 4.5 km/h Distance 0.657 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177383333" lon="13.1644583333">
+        <ele>551.5</ele>
+        <time>2010-08-26T16:11:11.826998Z</time>
+        <name>455</name>
+        <desc>Speed 3.96 km/h Distance 0.659 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177466667" lon="13.1644633333">
+        <ele>551.0</ele>
+        <time>2010-08-26T16:11:12.826998Z</time>
+        <name>456</name>
+        <desc>Speed 3.384 km/h Distance 0.66 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.94</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177566667" lon="13.1644616667">
+        <ele>550.5</ele>
+        <time>2010-08-26T16:11:13.826998Z</time>
+        <name>457</name>
+        <desc>Speed 3.348 km/h Distance 0.661 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177633333" lon="13.1644733333">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:11:14.846998Z</time>
+        <name>458</name>
+        <desc>Speed 2.988 km/h Distance 0.662 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177683333" lon="13.1644916667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:11:15.826998Z</time>
+        <name>459</name>
+        <desc>Speed 3.348 km/h Distance 0.663 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177816667" lon="13.16449">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:16.826998Z</time>
+        <name>460</name>
+        <desc>Speed 4.788 km/h Distance 0.665 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9177916667" lon="13.16449">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:17.826998Z</time>
+        <name>461</name>
+        <desc>Speed 4.176 km/h Distance 0.666 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178016667" lon="13.164485">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:18.826998Z</time>
+        <name>462</name>
+        <desc>Speed 4.14 km/h Distance 0.667 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91781" lon="13.16448">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:19.826998Z</time>
+        <name>463</name>
+        <desc>Speed 4.392 km/h Distance 0.668 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.22</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178183333" lon="13.16447">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:20.846998Z</time>
+        <name>464</name>
+        <desc>Speed 4.284 km/h Distance 0.669 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.19</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917825" lon="13.1644616667">
+        <ele>548.0</ele>
+        <time>2010-08-26T16:11:21.826998Z</time>
+        <name>465</name>
+        <desc>Speed 4.428 km/h Distance 0.67 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917835" lon="13.1644733333">
+        <ele>548.0</ele>
+        <time>2010-08-26T16:11:22.826998Z</time>
+        <name>466</name>
+        <desc>Speed 3.492 km/h Distance 0.672 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.97</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178416667" lon="13.1644616667">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:23.826998Z</time>
+        <name>467</name>
+        <desc>Speed 4.32 km/h Distance 0.673 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178483333" lon="13.1644616667">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:24.826998Z</time>
+        <name>468</name>
+        <desc>Speed 2.7 km/h Distance 0.674 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178566667" lon="13.1644633333">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:25.826998Z</time>
+        <name>469</name>
+        <desc>Speed 2.7 km/h Distance 0.674 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178616667" lon="13.16445">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:26.826998Z</time>
+        <name>470</name>
+        <desc>Speed 4.212 km/h Distance 0.676 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178683333" lon="13.164435">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:27.826998Z</time>
+        <name>471</name>
+        <desc>Speed 3.996 km/h Distance 0.677 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917875" lon="13.16444">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:28.836998Z</time>
+        <name>472</name>
+        <desc>Speed 2.448 km/h Distance 0.678 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.68</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178816667" lon="13.1644383333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:29.826998Z</time>
+        <name>473</name>
+        <desc>Speed 2.844 km/h Distance 0.679 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.79</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9178933333" lon="13.1644483333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:30.826998Z</time>
+        <name>474</name>
+        <desc>Speed 4.32 km/h Distance 0.68 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179116667" lon="13.1644666667">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:31.826998Z</time>
+        <name>475</name>
+        <desc>Speed 6.48 km/h Distance 0.682 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.8</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917915" lon="13.1644866667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:32.826998Z</time>
+        <name>476</name>
+        <desc>Speed 1.008 km/h Distance 0.684 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179316667" lon="13.1644766667">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:33.826998Z</time>
+        <name>477</name>
+        <desc>Speed 4.5 km/h Distance 0.686 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.917945" lon="13.1644633333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:34.826998Z</time>
+        <name>478</name>
+        <desc>Speed 4.644 km/h Distance 0.688 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179566667" lon="13.1644633333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:35.826998Z</time>
+        <name>479</name>
+        <desc>Speed 4.32 km/h Distance 0.689 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179683333" lon="13.1644566667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:11:36.826998Z</time>
+        <name>480</name>
+        <desc>Speed 3.672 km/h Distance 0.69 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9179816667" lon="13.1644566667">
+        <ele>550.0</ele>
+        <time>2010-08-26T16:11:37.826998Z</time>
+        <name>481</name>
+        <desc>Speed 3.6 km/h Distance 0.692 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180016667" lon="13.1644533333">
+        <ele>549.0</ele>
+        <time>2010-08-26T16:11:38.826998Z</time>
+        <name>482</name>
+        <desc>Speed 5.364 km/h Distance 0.694 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.49</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180183333" lon="13.1644516667">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:40.006998Z</time>
+        <name>483</name>
+        <desc>Speed 4.32 km/h Distance 0.696 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.2</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180316667" lon="13.1644383333">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:40.826998Z</time>
+        <name>484</name>
+        <desc>Speed 5.976 km/h Distance 0.698 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.66</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180483333" lon="13.1644333333">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:41.816998Z</time>
+        <name>485</name>
+        <desc>Speed 5.724 km/h Distance 0.7 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.59</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91807" lon="13.1644183333">
+        <ele>548.5</ele>
+        <time>2010-08-26T16:11:42.836998Z</time>
+        <name>486</name>
+        <desc>Speed 8.748 km/h Distance 0.702 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9180716667" lon="13.1644683333">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:11:43.826998Z</time>
+        <name>487</name>
+        <desc>Speed 3.78 km/h Distance 0.706 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918085" lon="13.1644483333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:11:44.826998Z</time>
+        <name>488</name>
+        <desc>Speed 4.644 km/h Distance 0.708 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181016667" lon="13.164425">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:11:45.826998Z</time>
+        <name>489</name>
+        <desc>Speed 4.428 km/h Distance 0.711 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181133333" lon="13.1644033333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:11:46.826998Z</time>
+        <name>490</name>
+        <desc>Speed 5.004 km/h Distance 0.713 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181283333" lon="13.1643783333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:11:47.826998Z</time>
+        <name>491</name>
+        <desc>Speed 4.644 km/h Distance 0.715 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181433333" lon="13.1643533333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:11:48.866998Z</time>
+        <name>492</name>
+        <desc>Speed 5.076 km/h Distance 0.718 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181566667" lon="13.16433">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:11:49.836998Z</time>
+        <name>493</name>
+        <desc>Speed 4.968 km/h Distance 0.72 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918155" lon="13.164315">
+        <ele>555.5</ele>
+        <time>2010-08-26T16:11:50.826998Z</time>
+        <name>494</name>
+        <desc>Speed 4.644 km/h Distance 0.721 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181616667" lon="13.1642983333">
+        <ele>555.5</ele>
+        <time>2010-08-26T16:11:51.826998Z</time>
+        <name>495</name>
+        <desc>Speed 4.212 km/h Distance 0.723 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.17</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918165" lon="13.1642816667">
+        <ele>556.0</ele>
+        <time>2010-08-26T16:11:52.826998Z</time>
+        <name>496</name>
+        <desc>Speed 3.888 km/h Distance 0.724 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.08</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181716667" lon="13.1642633333">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:11:53.826998Z</time>
+        <name>497</name>
+        <desc>Speed 3.6 km/h Distance 0.726 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918175" lon="13.1642466667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:11:54.836998Z</time>
+        <name>498</name>
+        <desc>Speed 3.132 km/h Distance 0.727 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181766667" lon="13.1642316667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:11:55.846998Z</time>
+        <name>499</name>
+        <desc>Speed 2.988 km/h Distance 0.728 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181783333" lon="13.1642216667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:11:56.816998Z</time>
+        <name>500</name>
+        <desc>Speed 1.44 km/h Distance 0.729 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181783333" lon="13.1642183333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:11:57.826998Z</time>
+        <name>501</name>
+        <desc>Speed 0.0 km/h Distance 0.729 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181783333" lon="13.1642183333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:11:58.826998Z</time>
+        <name>502</name>
+        <desc>Speed 0.18 km/h Distance 0.729 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181783333" lon="13.1642166667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:11:59.826998Z</time>
+        <name>503</name>
+        <desc>Speed 0.072 km/h Distance 0.729 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91818" lon="13.164215">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:00.826998Z</time>
+        <name>504</name>
+        <desc>Speed 0.036 km/h Distance 0.729 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181816667" lon="13.1642133333">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:01.826998Z</time>
+        <name>505</name>
+        <desc>Speed 0.108 km/h Distance 0.73 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181816667" lon="13.1642116667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:02.826998Z</time>
+        <name>506</name>
+        <desc>Speed 0.252 km/h Distance 0.73 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181833333" lon="13.1642116667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:03.826998Z</time>
+        <name>507</name>
+        <desc>Speed 0.036 km/h Distance 0.73 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9181783333" lon="13.1642066667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:04.826998Z</time>
+        <name>508</name>
+        <desc>Speed 2.268 km/h Distance 0.731 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.63</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918185" lon="13.1641916667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:05.836998Z</time>
+        <name>509</name>
+        <desc>Speed 3.384 km/h Distance 0.732 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.94</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91819" lon="13.1641783333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:06.826998Z</time>
+        <name>510</name>
+        <desc>Speed 3.636 km/h Distance 0.733 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918195" lon="13.1641633333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:07.826998Z</time>
+        <name>511</name>
+        <desc>Speed 3.42 km/h Distance 0.734 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.95</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182033333" lon="13.1641516667">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:08.826998Z</time>
+        <name>512</name>
+        <desc>Speed 3.78 km/h Distance 0.736 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91821" lon="13.1641366667">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:09.836998Z</time>
+        <name>513</name>
+        <desc>Speed 3.852 km/h Distance 0.737 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91822" lon="13.1641216667">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:10.816998Z</time>
+        <name>514</name>
+        <desc>Speed 4.68 km/h Distance 0.739 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91823" lon="13.1641083333">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:12.236998Z</time>
+        <name>515</name>
+        <desc>Speed 4.608 km/h Distance 0.74 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91824" lon="13.164095">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:12.816998Z</time>
+        <name>516</name>
+        <desc>Speed 4.68 km/h Distance 0.741 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182466667" lon="13.16408">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:13.816998Z</time>
+        <name>517</name>
+        <desc>Speed 3.6 km/h Distance 0.743 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182533333" lon="13.1640666667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:14.826998Z</time>
+        <name>518</name>
+        <desc>Speed 3.6 km/h Distance 0.744 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182566667" lon="13.164065">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:15.826998Z</time>
+        <name>519</name>
+        <desc>Speed 0.648 km/h Distance 0.744 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.18</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182616667" lon="13.1640583333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:16.816998Z</time>
+        <name>520</name>
+        <desc>Speed 2.16 km/h Distance 0.745 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.6</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182683333" lon="13.1640433333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:17.816998Z</time>
+        <name>521</name>
+        <desc>Speed 4.104 km/h Distance 0.747 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182783333" lon="13.1640266667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:18.826998Z</time>
+        <name>522</name>
+        <desc>Speed 4.932 km/h Distance 0.748 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918285" lon="13.164005">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:19.826998Z</time>
+        <name>523</name>
+        <desc>Speed 5.256 km/h Distance 0.75 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91829" lon="13.1639833333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:20.826998Z</time>
+        <name>524</name>
+        <desc>Speed 5.04 km/h Distance 0.752 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9182966667" lon="13.1639633333">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:21.816998Z</time>
+        <name>525</name>
+        <desc>Speed 4.932 km/h Distance 0.753 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918305" lon="13.163945">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:22.816998Z</time>
+        <name>526</name>
+        <desc>Speed 4.86 km/h Distance 0.755 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.35</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91831" lon="13.163925">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:23.826998Z</time>
+        <name>527</name>
+        <desc>Speed 4.824 km/h Distance 0.757 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183166667" lon="13.163905">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:24.826998Z</time>
+        <name>528</name>
+        <desc>Speed 4.68 km/h Distance 0.758 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91832" lon="13.1638866667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:25.816998Z</time>
+        <name>529</name>
+        <desc>Speed 4.572 km/h Distance 0.76 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183266667" lon="13.1638683333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:26.826998Z</time>
+        <name>530</name>
+        <desc>Speed 4.536 km/h Distance 0.761 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918335" lon="13.1638533333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:27.816998Z</time>
+        <name>531</name>
+        <desc>Speed 4.644 km/h Distance 0.763 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183433333" lon="13.1638366667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:28.816998Z</time>
+        <name>532</name>
+        <desc>Speed 5.112 km/h Distance 0.764 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.42</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183533333" lon="13.1638216667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:29.816998Z</time>
+        <name>533</name>
+        <desc>Speed 4.932 km/h Distance 0.766 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918365" lon="13.1638083333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:30.966998Z</time>
+        <name>534</name>
+        <desc>Speed 5.004 km/h Distance 0.767 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183733333" lon="13.163795">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:31.816998Z</time>
+        <name>535</name>
+        <desc>Speed 4.788 km/h Distance 0.769 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183833333" lon="13.1637833333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:32.816998Z</time>
+        <name>536</name>
+        <desc>Speed 4.752 km/h Distance 0.77 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9183933333" lon="13.16377">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:33.826998Z</time>
+        <name>537</name>
+        <desc>Speed 4.86 km/h Distance 0.772 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.35</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184016667" lon="13.163755">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:34.826998Z</time>
+        <name>538</name>
+        <desc>Speed 4.68 km/h Distance 0.773 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184116667" lon="13.1637416667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:35.826998Z</time>
+        <name>539</name>
+        <desc>Speed 4.644 km/h Distance 0.775 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184183333" lon="13.1637316667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:36.816998Z</time>
+        <name>540</name>
+        <desc>Speed 3.924 km/h Distance 0.776 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184283333" lon="13.1637216667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:37.876998Z</time>
+        <name>541</name>
+        <desc>Speed 4.032 km/h Distance 0.777 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184366667" lon="13.1637066667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:38.816998Z</time>
+        <name>542</name>
+        <desc>Speed 4.68 km/h Distance 0.779 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918445" lon="13.1636916667">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:12:39.816998Z</time>
+        <name>543</name>
+        <desc>Speed 4.932 km/h Distance 0.78 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184483333" lon="13.1636766667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:40.816998Z</time>
+        <name>544</name>
+        <desc>Speed 4.356 km/h Distance 0.781 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184533333" lon="13.163665">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:41.816998Z</time>
+        <name>545</name>
+        <desc>Speed 4.176 km/h Distance 0.782 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91846" lon="13.1636516667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:42.816998Z</time>
+        <name>546</name>
+        <desc>Speed 4.644 km/h Distance 0.783 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184683333" lon="13.1636366667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:12:43.826998Z</time>
+        <name>547</name>
+        <desc>Speed 5.22 km/h Distance 0.785 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.45</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184766667" lon="13.163625">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:44.826998Z</time>
+        <name>548</name>
+        <desc>Speed 4.68 km/h Distance 0.786 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184816667" lon="13.1636066667">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:12:45.826998Z</time>
+        <name>549</name>
+        <desc>Speed 5.436 km/h Distance 0.788 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918485" lon="13.1635916667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:12:46.816998Z</time>
+        <name>550</name>
+        <desc>Speed 5.436 km/h Distance 0.789 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184883333" lon="13.16358">
+        <ele>556.0</ele>
+        <time>2010-08-26T16:12:47.826998Z</time>
+        <name>551</name>
+        <desc>Speed 5.436 km/h Distance 0.79 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91849" lon="13.1635716667">
+        <ele>555.0</ele>
+        <time>2010-08-26T16:12:48.826998Z</time>
+        <name>552</name>
+        <desc>Speed 5.436 km/h Distance 0.79 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91849" lon="13.1635633333">
+        <ele>555.0</ele>
+        <time>2010-08-26T16:12:49.816998Z</time>
+        <name>553</name>
+        <desc>Speed 5.436 km/h Distance 0.791 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91849" lon="13.1635566667">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:12:50.816998Z</time>
+        <name>554</name>
+        <desc>Speed 5.436 km/h Distance 0.792 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184833333" lon="13.16355">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:12:51.826998Z</time>
+        <name>555</name>
+        <desc>Speed 2.016 km/h Distance 0.792 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184716667" lon="13.1635316667">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:12:52.826998Z</time>
+        <name>556</name>
+        <desc>Speed 1.08 km/h Distance 0.794 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91847" lon="13.1635166667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:12:53.826998Z</time>
+        <name>557</name>
+        <desc>Speed 2.088 km/h Distance 0.795 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.58</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184683333" lon="13.1635133333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:12:54.816998Z</time>
+        <name>558</name>
+        <desc>Speed 1.116 km/h Distance 0.796 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.31</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184616667" lon="13.163515">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:12:55.816998Z</time>
+        <name>559</name>
+        <desc>Speed 1.836 km/h Distance 0.797 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91846" lon="13.1635133333">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:12:56.826998Z</time>
+        <name>560</name>
+        <desc>Speed 0.756 km/h Distance 0.797 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91846" lon="13.16351">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:12:57.816998Z</time>
+        <name>561</name>
+        <desc>Speed 0.324 km/h Distance 0.797 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184516667" lon="13.1635">
+        <ele>555.5</ele>
+        <time>2010-08-26T16:12:58.816998Z</time>
+        <name>562</name>
+        <desc>Speed 1.008 km/h Distance 0.798 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184483333" lon="13.1635">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:12:59.816998Z</time>
+        <name>563</name>
+        <desc>Speed 0.072 km/h Distance 0.799 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.16347">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:01.816998Z</time>
+        <name>564</name>
+        <desc>Speed 0.18 km/h Distance 0.802 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.1634683333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:02.826998Z</time>
+        <name>565</name>
+        <desc>Speed 0.18 km/h Distance 0.802 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918425" lon="13.16347">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:03.826998Z</time>
+        <name>566</name>
+        <desc>Speed 0.18 km/h Distance 0.802 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.1634766667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:04.816998Z</time>
+        <name>567</name>
+        <desc>Speed 3.132 km/h Distance 0.803 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.163485">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:05.826998Z</time>
+        <name>568</name>
+        <desc>Speed 3.132 km/h Distance 0.803 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.1634916667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:13:06.816998Z</time>
+        <name>569</name>
+        <desc>Speed 3.132 km/h Distance 0.804 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184266667" lon="13.1634966667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:13:07.816998Z</time>
+        <name>570</name>
+        <desc>Speed 3.132 km/h Distance 0.804 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.87</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184233333" lon="13.163505">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:13:08.816998Z</time>
+        <name>571</name>
+        <desc>Speed 1.656 km/h Distance 0.805 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184233333" lon="13.1635016667">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:13:09.816998Z</time>
+        <name>572</name>
+        <desc>Speed 1.656 km/h Distance 0.805 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184233333" lon="13.1635033333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:13:10.826998Z</time>
+        <name>573</name>
+        <desc>Speed 4.176 km/h Distance 0.805 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.16</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918435" lon="13.1634966667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:13:11.816998Z</time>
+        <name>574</name>
+        <desc>Speed 5.292 km/h Distance 0.807 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.47</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184466667" lon="13.1634833333">
+        <ele>555.5</ele>
+        <time>2010-08-26T16:13:12.816998Z</time>
+        <name>575</name>
+        <desc>Speed 4.608 km/h Distance 0.808 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184583333" lon="13.1634633333">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:13:13.816998Z</time>
+        <name>576</name>
+        <desc>Speed 4.608 km/h Distance 0.81 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184683333" lon="13.1634383333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:13:14.816998Z</time>
+        <name>577</name>
+        <desc>Speed 4.608 km/h Distance 0.812 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184766667" lon="13.16342">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:15.816998Z</time>
+        <name>578</name>
+        <desc>Speed 4.608 km/h Distance 0.814 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.28</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9184833333" lon="13.1634183333">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:13:16.816998Z</time>
+        <name>579</name>
+        <desc>Speed 1.872 km/h Distance 0.815 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.52</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918495" lon="13.1634016667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:17.816998Z</time>
+        <name>580</name>
+        <desc>Speed 4.356 km/h Distance 0.817 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185016667" lon="13.1633833333">
+        <ele>554.0</ele>
+        <time>2010-08-26T16:13:18.816998Z</time>
+        <name>581</name>
+        <desc>Speed 2.52 km/h Distance 0.818 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.7</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185066667" lon="13.1633716667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:19.826998Z</time>
+        <name>582</name>
+        <desc>Speed 1.476 km/h Distance 0.819 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185083333" lon="13.16339">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:20.816998Z</time>
+        <name>583</name>
+        <desc>Speed 5.832 km/h Distance 0.821 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185116667" lon="13.1633783333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:21.816998Z</time>
+        <name>584</name>
+        <desc>Speed 2.52 km/h Distance 0.822 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.7</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91851" lon="13.1633583333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:22.816998Z</time>
+        <name>585</name>
+        <desc>Speed 4.068 km/h Distance 0.823 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91851" lon="13.16334">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:23.816998Z</time>
+        <name>586</name>
+        <desc>Speed 4.068 km/h Distance 0.824 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185166667" lon="13.1633216667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:24.806998Z</time>
+        <name>587</name>
+        <desc>Speed 3.384 km/h Distance 0.826 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.94</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185183333" lon="13.1633116667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:13:25.816998Z</time>
+        <name>588</name>
+        <desc>Speed 1.8 km/h Distance 0.827 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.5</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91851" lon="13.1632916667">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:13:26.816998Z</time>
+        <name>589</name>
+        <desc>Speed 5.076 km/h Distance 0.829 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918505" lon="13.1632766667">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:27.816998Z</time>
+        <name>590</name>
+        <desc>Speed 5.076 km/h Distance 0.83 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.41</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185116667" lon="13.1632583333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:28.816998Z</time>
+        <name>591</name>
+        <desc>Speed 3.924 km/h Distance 0.831 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185216667" lon="13.16325">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:29.816998Z</time>
+        <name>592</name>
+        <desc>Speed 3.636 km/h Distance 0.833 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185316667" lon="13.1632366667">
+        <ele>552.5</ele>
+        <time>2010-08-26T16:13:30.816998Z</time>
+        <name>593</name>
+        <desc>Speed 4.14 km/h Distance 0.834 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185433333" lon="13.1632283333">
+        <ele>553.0</ele>
+        <time>2010-08-26T16:13:31.816998Z</time>
+        <name>594</name>
+        <desc>Speed 3.204 km/h Distance 0.836 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.89</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185466667" lon="13.163225">
+        <ele>555.0</ele>
+        <time>2010-08-26T16:13:32.826998Z</time>
+        <name>595</name>
+        <desc>Speed 2.448 km/h Distance 0.836 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.68</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91856" lon="13.163225">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:13:33.816998Z</time>
+        <name>596</name>
+        <desc>Speed 3.78 km/h Distance 0.838 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91857" lon="13.163225">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:13:34.816998Z</time>
+        <name>597</name>
+        <desc>Speed 3.78 km/h Distance 0.839 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9185766667" lon="13.163225">
+        <ele>554.5</ele>
+        <time>2010-08-26T16:13:35.826998Z</time>
+        <name>598</name>
+        <desc>Speed 3.78 km/h Distance 0.839 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186" lon="13.16322">
+        <ele>553.5</ele>
+        <time>2010-08-26T16:13:36.826998Z</time>
+        <name>599</name>
+        <desc>Speed 4.104 km/h Distance 0.842 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186116667" lon="13.1632033333">
+        <ele>555.0</ele>
+        <time>2010-08-26T16:13:37.826998Z</time>
+        <name>600</name>
+        <desc>Speed 3.528 km/h Distance 0.844 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186283333" lon="13.16318">
+        <ele>555.5</ele>
+        <time>2010-08-26T16:13:38.816998Z</time>
+        <name>601</name>
+        <desc>Speed 4.932 km/h Distance 0.846 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186466667" lon="13.1631633333">
+        <ele>556.0</ele>
+        <time>2010-08-26T16:13:39.816998Z</time>
+        <name>602</name>
+        <desc>Speed 3.636 km/h Distance 0.849 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186683333" lon="13.1631566667">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:13:40.826998Z</time>
+        <name>603</name>
+        <desc>Speed 3.6 km/h Distance 0.851 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186833333" lon="13.163155">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:13:41.826998Z</time>
+        <name>604</name>
+        <desc>Speed 3.348 km/h Distance 0.853 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9186916667" lon="13.1631533333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:13:42.826998Z</time>
+        <name>605</name>
+        <desc>Speed 1.98 km/h Distance 0.854 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.55</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187066667" lon="13.1631533333">
+        <ele>558.5</ele>
+        <time>2010-08-26T16:13:43.826998Z</time>
+        <name>606</name>
+        <desc>Speed 2.88 km/h Distance 0.855 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.8</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91872" lon="13.1631483333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:13:44.856998Z</time>
+        <name>607</name>
+        <desc>Speed 4.104 km/h Distance 0.857 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187333333" lon="13.163145">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:45.826998Z</time>
+        <name>608</name>
+        <desc>Speed 3.708 km/h Distance 0.859 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187433333" lon="13.1631466667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:46.826998Z</time>
+        <name>609</name>
+        <desc>Speed 3.528 km/h Distance 0.86 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.98</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187566667" lon="13.1631516667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:13:47.826998Z</time>
+        <name>610</name>
+        <desc>Speed 3.204 km/h Distance 0.861 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.89</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187683333" lon="13.1631516667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:13:48.826998Z</time>
+        <name>611</name>
+        <desc>Speed 3.96 km/h Distance 0.862 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187766667" lon="13.16315">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:13:49.816998Z</time>
+        <name>612</name>
+        <desc>Speed 1.548 km/h Distance 0.863 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.43</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187783333" lon="13.1631516667">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:13:50.826998Z</time>
+        <name>613</name>
+        <desc>Speed 0.036 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91878" lon="13.16315">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:13:51.816998Z</time>
+        <name>614</name>
+        <desc>Speed 0.252 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91878" lon="13.1631483333">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:13:52.826998Z</time>
+        <name>615</name>
+        <desc>Speed 0.18 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91878" lon="13.1631483333">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:13:53.816998Z</time>
+        <name>616</name>
+        <desc>Speed 0.396 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91878" lon="13.1631466667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:13:54.816998Z</time>
+        <name>617</name>
+        <desc>Speed 0.036 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91878" lon="13.163145">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:13:55.806998Z</time>
+        <name>618</name>
+        <desc>Speed 0.252 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187816667" lon="13.1631433333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:13:56.816998Z</time>
+        <name>619</name>
+        <desc>Speed 0.0 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187816667" lon="13.1631433333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:57.826998Z</time>
+        <name>620</name>
+        <desc>Speed 0.072 km/h Distance 0.864 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187816667" lon="13.1631416667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:58.816998Z</time>
+        <name>621</name>
+        <desc>Speed 0.252 km/h Distance 0.865 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187816667" lon="13.1631416667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:13:59.816998Z</time>
+        <name>622</name>
+        <desc>Speed 0.54 km/h Distance 0.865 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.15</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918785" lon="13.1631366667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:00.816998Z</time>
+        <name>623</name>
+        <desc>Speed 2.016 km/h Distance 0.865 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187916667" lon="13.16313">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:01.826998Z</time>
+        <name>624</name>
+        <desc>Speed 2.016 km/h Distance 0.866 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.56</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9187983333" lon="13.1631266667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:02.826998Z</time>
+        <name>625</name>
+        <desc>Speed 2.7 km/h Distance 0.867 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188066667" lon="13.1631233333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:03.816998Z</time>
+        <name>626</name>
+        <desc>Speed 2.52 km/h Distance 0.868 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.7</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918815" lon="13.1631166667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:04.816998Z</time>
+        <name>627</name>
+        <desc>Speed 2.916 km/h Distance 0.869 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.81</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188233333" lon="13.1631083333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:05.816998Z</time>
+        <name>628</name>
+        <desc>Speed 3.348 km/h Distance 0.87 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.93</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918835" lon="13.1631033333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:06.816998Z</time>
+        <name>629</name>
+        <desc>Speed 3.924 km/h Distance 0.871 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.09</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188483333" lon="13.1630916667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:07.886998Z</time>
+        <name>630</name>
+        <desc>Speed 4.752 km/h Distance 0.873 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91886" lon="13.1630816667">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:08.816998Z</time>
+        <name>631</name>
+        <desc>Speed 4.752 km/h Distance 0.874 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188716667" lon="13.163075">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:09.816998Z</time>
+        <name>632</name>
+        <desc>Speed 4.104 km/h Distance 0.876 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188833333" lon="13.16307">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:10.816998Z</time>
+        <name>633</name>
+        <desc>Speed 4.5 km/h Distance 0.877 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188966667" lon="13.16307">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:14:11.826998Z</time>
+        <name>634</name>
+        <desc>Speed 3.42 km/h Distance 0.879 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.95</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189133333" lon="13.1630633333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:14:12.816998Z</time>
+        <name>635</name>
+        <desc>Speed 4.788 km/h Distance 0.881 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189283333" lon="13.1630583333">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:14:13.816998Z</time>
+        <name>636</name>
+        <desc>Speed 4.428 km/h Distance 0.882 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.23</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918945" lon="13.1630533333">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:14:14.816998Z</time>
+        <name>637</name>
+        <desc>Speed 5.256 km/h Distance 0.884 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.46</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189583333" lon="13.1630466667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:15.816998Z</time>
+        <name>638</name>
+        <desc>Speed 3.708 km/h Distance 0.886 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189683333" lon="13.1630466667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:16.826998Z</time>
+        <name>639</name>
+        <desc>Speed 2.232 km/h Distance 0.887 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.62</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189816667" lon="13.16304">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:17.816998Z</time>
+        <name>640</name>
+        <desc>Speed 4.068 km/h Distance 0.888 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189916667" lon="13.16303">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:18.816998Z</time>
+        <name>641</name>
+        <desc>Speed 4.068 km/h Distance 0.89 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190033333" lon="13.1630216667">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:14:19.826998Z</time>
+        <name>642</name>
+        <desc>Speed 3.672 km/h Distance 0.891 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919015" lon="13.163015">
+        <ele>558.0</ele>
+        <time>2010-08-26T16:14:20.846998Z</time>
+        <name>643</name>
+        <desc>Speed 4.572 km/h Distance 0.893 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190183333" lon="13.1630033333">
+        <ele>557.0</ele>
+        <time>2010-08-26T16:14:21.816998Z</time>
+        <name>644</name>
+        <desc>Speed 2.988 km/h Distance 0.894 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.83</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190266667" lon="13.1629916667">
+        <ele>556.5</ele>
+        <time>2010-08-26T16:14:22.826998Z</time>
+        <name>645</name>
+        <desc>Speed 3.204 km/h Distance 0.895 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.89</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190383333" lon="13.1629883333">
+        <ele>557.5</ele>
+        <time>2010-08-26T16:14:23.816998Z</time>
+        <name>646</name>
+        <desc>Speed 2.448 km/h Distance 0.896 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.68</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190516667" lon="13.1629883333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:24.816998Z</time>
+        <name>647</name>
+        <desc>Speed 2.7 km/h Distance 0.898 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.75</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91907" lon="13.1629866667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:25.816998Z</time>
+        <name>648</name>
+        <desc>Speed 4.932 km/h Distance 0.9 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190633333" lon="13.1629583333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:26.816998Z</time>
+        <name>649</name>
+        <desc>Speed 8.604 km/h Distance 0.902 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919065" lon="13.1629383333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:27.816998Z</time>
+        <name>650</name>
+        <desc>Speed 5.22 km/h Distance 0.903 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.45</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190666667" lon="13.16292">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:28.816998Z</time>
+        <name>651</name>
+        <desc>Speed 4.896 km/h Distance 0.905 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.36</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190666667" lon="13.1629016667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:29.816998Z</time>
+        <name>652</name>
+        <desc>Speed 4.572 km/h Distance 0.906 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91906" lon="13.162885">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:30.816998Z</time>
+        <name>653</name>
+        <desc>Speed 5.436 km/h Distance 0.908 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919055" lon="13.16287">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:31.816998Z</time>
+        <name>654</name>
+        <desc>Speed 4.356 km/h Distance 0.909 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.21</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190483333" lon="13.1628566667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:32.816998Z</time>
+        <name>655</name>
+        <desc>Speed 3.96 km/h Distance 0.91 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190416667" lon="13.1628466667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:33.816998Z</time>
+        <name>656</name>
+        <desc>Speed 3.276 km/h Distance 0.911 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.91</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190333333" lon="13.1628316667">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:34.816998Z</time>
+        <name>657</name>
+        <desc>Speed 5.04 km/h Distance 0.913 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190283333" lon="13.1628183333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:35.826998Z</time>
+        <name>658</name>
+        <desc>Speed 3.6 km/h Distance 0.914 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190266667" lon="13.162805">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:36.816998Z</time>
+        <name>659</name>
+        <desc>Speed 4.068 km/h Distance 0.915 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190283333" lon="13.1627866667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:37.816998Z</time>
+        <name>660</name>
+        <desc>Speed 3.996 km/h Distance 0.916 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919025" lon="13.1627633333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:38.816998Z</time>
+        <name>661</name>
+        <desc>Speed 5.364 km/h Distance 0.918 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.49</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190233333" lon="13.1627416667">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:39.816998Z</time>
+        <name>662</name>
+        <desc>Speed 5.508 km/h Distance 0.92 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.53</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190216667" lon="13.1627283333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:40.816998Z</time>
+        <name>663</name>
+        <desc>Speed 3.996 km/h Distance 0.921 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.11</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190233333" lon="13.162715">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:41.806998Z</time>
+        <name>664</name>
+        <desc>Speed 2.664 km/h Distance 0.922 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.74</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91902" lon="13.1627">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:42.836998Z</time>
+        <name>665</name>
+        <desc>Speed 3.168 km/h Distance 0.923 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.88</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190216667" lon="13.1626883333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:43.816998Z</time>
+        <name>666</name>
+        <desc>Speed 1.188 km/h Distance 0.924 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190283333" lon="13.162635">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:45.806998Z</time>
+        <name>667</name>
+        <desc>Speed 3.744 km/h Distance 0.928 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.04</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919025" lon="13.1626233333">
+        <ele>559.0</ele>
+        <time>2010-08-26T16:14:46.806998Z</time>
+        <name>668</name>
+        <desc>Speed 2.268 km/h Distance 0.929 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.63</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190183333" lon="13.1626083333">
+        <ele>559.5</ele>
+        <time>2010-08-26T16:14:47.816998Z</time>
+        <name>669</name>
+        <desc>Speed 4.032 km/h Distance 0.93 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.12</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9190116667" lon="13.1625833333">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:48.816998Z</time>
+        <name>670</name>
+        <desc>Speed 3.6 km/h Distance 0.932 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.0</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.919005" lon="13.162555">
+        <ele>560.0</ele>
+        <time>2010-08-26T16:14:49.816998Z</time>
+        <name>671</name>
+        <desc>Speed 4.068 km/h Distance 0.934 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.13</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918995" lon="13.1625283333">
+        <ele>560.5</ele>
+        <time>2010-08-26T16:14:50.816998Z</time>
+        <name>672</name>
+        <desc>Speed 4.5 km/h Distance 0.937 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189866667" lon="13.1625">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:14:51.816998Z</time>
+        <name>673</name>
+        <desc>Speed 5.328 km/h Distance 0.939 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.48</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189783333" lon="13.1624733333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:52.816998Z</time>
+        <name>674</name>
+        <desc>Speed 5.004 km/h Distance 0.941 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.39</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91897" lon="13.162455">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:53.826998Z</time>
+        <name>675</name>
+        <desc>Speed 4.968 km/h Distance 0.943 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189616667" lon="13.1624383333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:54.816998Z</time>
+        <name>676</name>
+        <desc>Speed 4.752 km/h Distance 0.944 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189566667" lon="13.16242">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:55.826998Z</time>
+        <name>677</name>
+        <desc>Speed 4.68 km/h Distance 0.946 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189533333" lon="13.1624033333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:56.816998Z</time>
+        <name>678</name>
+        <desc>Speed 4.824 km/h Distance 0.947 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189466667" lon="13.162385">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:57.816998Z</time>
+        <name>679</name>
+        <desc>Speed 5.22 km/h Distance 0.949 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.45</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91894" lon="13.1623683333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:58.816998Z</time>
+        <name>680</name>
+        <desc>Speed 5.184 km/h Distance 0.95 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189333333" lon="13.1623533333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:14:59.816998Z</time>
+        <name>681</name>
+        <desc>Speed 4.968 km/h Distance 0.951 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189283333" lon="13.1623333333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:00.816998Z</time>
+        <name>682</name>
+        <desc>Speed 5.184 km/h Distance 0.953 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.44</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189233333" lon="13.162315">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:01.816998Z</time>
+        <name>683</name>
+        <desc>Speed 4.932 km/h Distance 0.954 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189183333" lon="13.1622983333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:02.816998Z</time>
+        <name>684</name>
+        <desc>Speed 4.752 km/h Distance 0.956 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189133333" lon="13.16228">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:03.816998Z</time>
+        <name>685</name>
+        <desc>Speed 4.968 km/h Distance 0.957 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189066667" lon="13.1622616667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:04.816998Z</time>
+        <name>686</name>
+        <desc>Speed 4.968 km/h Distance 0.959 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.38</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9189" lon="13.162245">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:05.816998Z</time>
+        <name>687</name>
+        <desc>Speed 4.644 km/h Distance 0.96 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.29</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918895" lon="13.1622266667">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:06.816998Z</time>
+        <name>688</name>
+        <desc>Speed 5.04 km/h Distance 0.962 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.4</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91889" lon="13.16221">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:07.816998Z</time>
+        <name>689</name>
+        <desc>Speed 4.932 km/h Distance 0.963 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918885" lon="13.1621933333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:08.816998Z</time>
+        <name>690</name>
+        <desc>Speed 4.788 km/h Distance 0.964 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.33</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91888" lon="13.1621766667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:09.816998Z</time>
+        <name>691</name>
+        <desc>Speed 4.824 km/h Distance 0.966 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.34</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188733333" lon="13.1621616667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:10.816998Z</time>
+        <name>692</name>
+        <desc>Speed 4.932 km/h Distance 0.967 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91887" lon="13.1621433333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:11.826998Z</time>
+        <name>693</name>
+        <desc>Speed 4.68 km/h Distance 0.969 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.3</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918865" lon="13.1621283333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:12.816998Z</time>
+        <name>694</name>
+        <desc>Speed 4.572 km/h Distance 0.97 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.27</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91886" lon="13.1621116667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:13.816998Z</time>
+        <name>695</name>
+        <desc>Speed 4.752 km/h Distance 0.971 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.32</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918855" lon="13.162095">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:14.816998Z</time>
+        <name>696</name>
+        <desc>Speed 4.536 km/h Distance 0.973 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91885" lon="13.1620783333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:15.826998Z</time>
+        <name>697</name>
+        <desc>Speed 4.86 km/h Distance 0.974 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.35</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918845" lon="13.1620616667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:16.816998Z</time>
+        <name>698</name>
+        <desc>Speed 4.536 km/h Distance 0.975 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.26</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188433333" lon="13.1620483333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:18.066998Z</time>
+        <name>699</name>
+        <desc>Speed 3.888 km/h Distance 0.976 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.08</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188416667" lon="13.1620433333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:18.816998Z</time>
+        <name>700</name>
+        <desc>Speed 1.836 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.51</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188416667" lon="13.1620416667">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:19.816998Z</time>
+        <name>701</name>
+        <desc>Speed 0.36 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91884" lon="13.1620433333">
+        <ele>561.0</ele>
+        <time>2010-08-26T16:15:21.026998Z</time>
+        <name>702</name>
+        <desc>Speed 0.252 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91884" lon="13.1620433333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:21.816998Z</time>
+        <name>703</name>
+        <desc>Speed 0.108 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188383333" lon="13.1620433333">
+        <ele>561.5</ele>
+        <time>2010-08-26T16:15:22.816998Z</time>
+        <name>704</name>
+        <desc>Speed 0.18 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188366667" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:23.876998Z</time>
+        <name>705</name>
+        <desc>Speed 0.108 km/h Distance 0.977 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918835" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:24.816998Z</time>
+        <name>706</name>
+        <desc>Speed 0.252 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918835" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:25.826998Z</time>
+        <name>707</name>
+        <desc>Speed 0.108 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918835" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:26.816998Z</time>
+        <name>708</name>
+        <desc>Speed 0.108 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.03</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.918835" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:27.816998Z</time>
+        <name>709</name>
+        <desc>Speed 0.18 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.0</ele>
+        <time>2010-08-26T16:15:28.806998Z</time>
+        <name>710</name>
+        <desc>Speed 0.036 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.01</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:29.816998Z</time>
+        <name>711</name>
+        <desc>Speed 0.072 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.02</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:30.816998Z</time>
+        <name>712</name>
+        <desc>Speed 0.18 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:31.816998Z</time>
+        <name>713</name>
+        <desc>Speed 0.18 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.05</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:32.816998Z</time>
+        <name>714</name>
+        <desc>Speed 0.252 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:33.816998Z</time>
+        <name>715</name>
+        <desc>Speed 0.252 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188333333" lon="13.1620433333">
+        <ele>562.5</ele>
+        <time>2010-08-26T16:15:34.806998Z</time>
+        <name>716</name>
+        <desc>Speed 0.36 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.1</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91883" lon="13.1620433333">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:15:35.926998Z</time>
+        <name>717</name>
+        <desc>Speed 0.9 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.25</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.91883" lon="13.162045">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:15:36.816998Z</time>
+        <name>718</name>
+        <desc>Speed 0.504 km/h Distance 0.978 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.14</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188283333" lon="13.1620466667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:15:37.816998Z</time>
+        <name>719</name>
+        <desc>Speed 1.332 km/h Distance 0.979 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.37</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.9188283333" lon="13.1620466667">
+        <ele>563.0</ele>
+        <time>2010-08-26T16:15:38.806998Z</time>
+        <name>720</name>
+        <desc>Speed 0.252 km/h Distance 0.979 km</desc>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.07</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
A track file of 10000 <= version < 20000, say version 1, was found at the following web site.
https://sourceforge.net/p/gpsbabel/mailman/message/26219411/

Its trackpoint format was found to be those of the new type, while the ver. 1 route file in my phone was of the old type
(similar to the version < 10000 trackfiles).

So, it seems to me that the ver. 1 formats of track and route are different each other.